### PR TITLE
Fix erronious example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ It should contain a map with some global configuration and a `:builds` entry for
   {:target :browser
    :output-dir "public/js"
    :asset-path "/js"
-   :modules {:main [my.app]}}}}
+   :modules {:main {:entries [my.app]}}}}}
 ```
 
 - `:dependencies` manage your CLJS dependencies in the same format as `leiningen` or `boot`


### PR DESCRIPTION
This makes the snippet README(wrong) consistent with this [wiki entry](https://github.com/thheller/shadow-cljs/wiki/ClojureScript-for-JS-Devs) (correct)