### PR TITLE
Check compiler state before loading namespace from source

### DIFF
--- a/src/main/shadow/cljs/bootstrap/browser.cljs
+++ b/src/main/shadow/cljs/bootstrap/browser.cljs
@@ -159,7 +159,8 @@
   (let [ns (if macros
              (symbol (str name "$macros"))
              name)]
-    (env/get-ns-info ns)
+    (or (get-in @compile-state-ref [:cljs.analyzer/namespaces ns])
+        (env/get-ns-info ns))
     (load-namespaces compile-state-ref #{ns} cb)))
 
 (defn fix-provide-conflict! []


### PR DESCRIPTION
per https://dev.clojure.org/jira/browse/CLJS-1473, it appears to be a bug in many ClojureScript REPLs that one can't `require` a namespace created in the REPL.

I've tried this patch with Maria and it seems to work as expected. The only situation I can think of where this could be a problem is if you really wanted to _reload_ a namespace, that seems to be a special case and I'm not sure if we have logic for that anywhere.