### PR TITLE
Fix broken error handling for nrepl-server and fixed the default for …

### DIFF
--- a/src/main/shadow/cljs/devtools/server/worker/impl.clj
+++ b/src/main/shadow/cljs/devtools/server/worker/impl.clj
@@ -72,6 +72,7 @@
   {:type :repl/error
    :message (.getMessage e)
    :data (ex-data e)
+   :ex e
    :causes
    (loop [e (.getCause e)
           causes []]


### PR DESCRIPTION
…case

This makes the repl a lot more usable already for cider the following things already work. The only thing I am still running into if I want to eval a namespace with a clojure alias like: `clojure.pprint` `clojure.spec.alpha` then it breaks with the following exception:

```
clojure.lang.ExceptionInfo: failed to compile resource: [:shadow.build.classpath/resource "cljs/pprint.cljs"]
 at clojure.core$ex_info.invokeStatic (core.clj:4739)
    clojure.core$ex_info.invoke (core.clj:4739)
    shadow.build.compiler$maybe_compile_cljs$fn__27174.invoke (compiler.clj:606)
    shadow.build.compiler$maybe_compile_cljs.invokeStatic (compiler.clj:570)
    shadow.build.compiler$maybe_compile_cljs.invoke (compiler.clj:550)
    shadow.build.compiler$generate_output_for_source.invokeStatic (compiler.clj:624)
    shadow.build.compiler$generate_output_for_source.invoke (compiler.clj:614)
    shadow.build.compiler$par_compile_one.invokeStatic (compiler.clj:667)
    shadow.build.compiler$par_compile_one.invoke (compiler.clj:627)
    shadow.build.compiler$par_compile_cljs_sources$fn__27202$iter__27203__27207$fn__27208$fn__27209$fn__27210.invoke (compiler.clj:726)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$with_bindings_STAR_.invokeStatic (core.clj:1965)
    clojure.core$with_bindings_STAR_.doInvoke (core.clj:1965)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.core$apply.invokeStatic (core.clj:661)
    clojure.core$bound_fn_STAR_$fn__5471.doInvoke (core.clj:1995)
    clojure.lang.RestFn.invoke (RestFn.java:397)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:266)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    java.lang.Thread.run (Thread.java:748)
Caused by: java.lang.Exception: No namespace: cljs.pprint found
 at clojure.core$the_ns.invokeStatic (core.clj:4128)
    clojure.core$ns_publics.invokeStatic (core.clj:4155)
    clojure.core$ns_publics.invoke (core.clj:4155)
    shadow.build.macros$find_macros_in_ns.invokeStatic (macros.clj:32)
    shadow.build.macros$find_macros_in_ns.invoke (macros.clj:30)
    shadow.build.macros$load_macros.invokeStatic (macros.clj:80)
    shadow.build.macros$load_macros.invoke (macros.clj:50)
    shadow.build.compiler$post_analyze_ns.invokeStatic (compiler.clj:43)
    shadow.build.compiler$post_analyze_ns.invoke (compiler.clj:40)
    shadow.build.compiler$post_analyze.invokeStatic (compiler.clj:73)
    shadow.build.compiler$post_analyze.invoke (compiler.clj:70)
    shadow.build.compiler$analyze.invokeStatic (compiler.clj:138)
    shadow.build.compiler$analyze.invoke (compiler.clj:101)
    shadow.build.compiler$analyze.invokeStatic (compiler.clj:103)
    shadow.build.compiler$analyze.invoke (compiler.clj:101)
    shadow.build.compiler$default_compile_cljs.invokeStatic (compiler.clj:237)
    shadow.build.compiler$default_compile_cljs.invoke (compiler.clj:234)
    clojure.core$partial$fn__5561.invoke (core.clj:2617)
    shadow.build.compiler$do_compile_cljs_string$fn__27054.invoke (compiler.clj:185)
    shadow.build.compiler$do_compile_cljs_string.invokeStatic (compiler.clj:155)
    shadow.build.compiler$do_compile_cljs_string.invoke (compiler.clj:140)
    shadow.build.compiler$compile_cljs_string$fn__27101.invoke (compiler.clj:293)
    shadow.build.compiler$compile_cljs_string.invokeStatic (compiler.clj:292)
    shadow.build.compiler$compile_cljs_string.invoke (compiler.clj:290)
    shadow.build.compiler$do_compile_cljs_resource$fn__27119.invoke (compiler.clj:369)
    shadow.build.compiler$do_compile_cljs_resource.invokeStatic (compiler.clj:352)
    shadow.build.compiler$do_compile_cljs_resource.invoke (compiler.clj:314)
    shadow.build.compiler$maybe_compile_cljs$fn__27174.invoke (compiler.clj:571)
    shadow.build.compiler$maybe_compile_cljs.invokeStatic (compiler.clj:570)
    shadow.build.compiler$maybe_compile_cljs.invoke (compiler.clj:550)
    shadow.build.compiler$generate_output_for_source.invokeStatic (compiler.clj:624)
    shadow.build.compiler$generate_output_for_source.invoke (compiler.clj:614)
    shadow.build.compiler$par_compile_one.invokeStatic (compiler.clj:667)
    shadow.build.compiler$par_compile_one.invoke (compiler.clj:627)
    shadow.build.compiler$par_compile_cljs_sources$fn__27202$iter__27203__27207$fn__27208$fn__27209$fn__27210.invoke (compiler.clj:726)
    clojure.lang.AFn.applyToHelper (AFn.java:152)
    clojure.lang.AFn.applyTo (AFn.java:144)
    clojure.core$apply.invokeStatic (core.clj:657)
    clojure.core$with_bindings_STAR_.invokeStatic (core.clj:1965)
    clojure.core$with_bindings_STAR_.doInvoke (core.clj:1965)
    clojure.lang.RestFn.invoke (RestFn.java:425)
    clojure.lang.AFn.applyToHelper (AFn.java:156)
    clojure.lang.RestFn.applyTo (RestFn.java:132)
    clojure.core$apply.invokeStatic (core.clj:661)
    clojure.core$bound_fn_STAR_$fn__5471.doInvoke (core.clj:1995)
    clojure.lang.RestFn.invoke (RestFn.java:397)
    clojure.lang.AFn.call (AFn.java:18)
    java.util.concurrent.FutureTask.run (FutureTask.java:266)
    java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1149)
    java.util.concurrent.ThreadPoolExecutor$Worker.run (ThreadPoolExecutor.java:624)
    java.lang.Thread.run (Thread.java:748)

```