### PR TITLE
Fix an issue of running the cli/runner.js script on Windows platform

### DIFF
--- a/packages/shadow-cljs/package.json
+++ b/packages/shadow-cljs/package.json
@@ -24,7 +24,7 @@
     "node": ">=6.0.0"
   },
   "scripts": {
-    "install":"./cli/runner.js aot"
+    "install":"node ./cli/runner.js aot"
   },
   "dependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
I always get an error message as below when I try to upgrade shaow-cljs.

I modified the "install" script in package.json to resolve the issue and it works, please review my change.

![s1](https://user-images.githubusercontent.com/5813426/34461206-ae18a61a-ee5f-11e7-9552-0833e9e584a1.png)

Thanks
Huabin