### PR TITLE
Print bundle info table from release snapshot

### DIFF
--- a/src/main/shadow/cljs/devtools/api.clj
+++ b/src/main/shadow/cljs/devtools/api.clj
@@ -24,7 +24,8 @@
     [shadow.cljs.devtools.server.runtime :as runtime]
     [shadow.build.output :as output]
     [shadow.build.log :as build-log]
-    [shadow.core-ext :as core-ext]))
+    [shadow.core-ext :as core-ext]
+    [shadow.cljs.devtools.release-snapshot :as snapshot]))
 
 ;; nREPL support
 
@@ -493,12 +494,15 @@
 
       (spit
         (io/file output-dir "bundle-info.edn")
-        (core-ext/safe-pr-str bundle-info)))
+        (core-ext/safe-pr-str bundle-info))
+
+      (snapshot/print-bundle-info-table bundle-info))
 
     :done
     ))
 
 (comment
+  (release-snapshot :browser {})
 
   (defn node-execute! [node-args file]
     (let [script-args

--- a/src/main/shadow/cljs/devtools/release_snapshot.clj
+++ b/src/main/shadow/cljs/devtools/release_snapshot.clj
@@ -1,0 +1,57 @@
+(ns shadow.cljs.devtools.release-snapshot
+  (:require [clojure.pprint :as pprint]
+            [clojure.string :as str]
+            [shadow.build :as build]))
+
+(defn format-byte-size [size]
+  (loop [i 0 size (double size)]
+    (if (< size 1000)
+      (format "%.1f %s" size (nth ["B" "KB" "MB" "GB" "TB" "PB"] i))
+      (recur (inc i) (/ size 1000)))))
+
+(defn print-table [ks rows]
+  (print "\u001B[1m")
+  ;(print "\u001B[33m")
+  (pprint/print-table ks rows)
+  (print "\u001B[m"))
+
+(defn short-resource-name [resource-name]
+  (cond
+    (str/includes? resource-name "node_modules")
+    (second (str/split resource-name #"/"))
+    :else resource-name))
+
+(defn get-optimized-info [build-modules]
+  (->> build-modules
+       (map (fn [module]
+              (->> (:source-bytes module)
+                   (map (fn [[module-name bytes]] [module-name {:optimized-size bytes}]))
+                   (into {}))))
+       (reduce (partial merge-with +))))
+
+(defn get-unoptimized-info [build-sources]
+  (reduce
+    (fn [m x]
+      (assoc m (:resource-name x) (select-keys x [:js-size :source-size])))
+    {}
+    build-sources))
+
+(defn get-bundle-summary [{:keys [build-modules build-sources] :as bundle-info}]
+  (let [optimized (get-optimized-info build-modules)
+        raw (get-unoptimized-info build-sources)
+        merged (build/deep-merge optimized raw)]
+    (->> merged
+         (group-by (fn [[k _]] (short-resource-name k)))
+         (map (fn [[k v]]
+                (let [resource-totals (->> v (map second) (reduce (partial merge-with +)))]
+                  (assoc resource-totals :short-resource-name k)))))))
+
+(defn print-bundle-info-table [bundle-info]
+  (->> (get-bundle-summary bundle-info)
+       (sort-by #(or (:optimized-size %) 0) >)
+       (map (fn [{:keys [short-resource-name source-size js-size optimized-size]}]
+              {"Resource name" short-resource-name
+               "Optimized size" (some-> optimized-size (format-byte-size))
+               "Source size" (some-> source-size (format-byte-size))
+               "JS size" (some-> js-size (format-byte-size))}))
+       (print-table ["Resource name" "Optimized size" "JS size" "Source size"])))


### PR DESCRIPTION
#247 

Calling `release-snapshot` will now also print a table to the console like the following:

```
|                         Resource name | JS size | Source size |
|---------------------------------------+---------+-------------|
|                        cljs/core.cljs |   1.3MB |     330.8KB |
|                      cljs/pprint.cljs | 521.6KB |     127.9KB |
|                  cljs/core/async.cljs | 295.1KB |      31.1KB |
|                  cljs/spec/alpha.cljs | 290.8KB |      52.2KB |
|                       goog/dom/dom.js | 111.2KB |     111.2KB |
|              cljs/spec/gen/alpha.cljs | 105.8KB |       6.0KB |
|                       shadow/dom.cljs |  97.6KB |      17.4KB |
|                          goog/base.js |  97.3KB |      97.3KB |
|                cljs/tools/reader.cljs |  83.7KB |      33.9KB |
|                   goog/style/style.js |  75.9KB |      75.9KB |
|                   goog/array/array.js |  59.4KB |      59.4KB |
|                 goog/string/string.js |  53.2KB |      53.2KB |
|                     goog/iter/iter.js |  44.0KB |      44.0KB |
|                       goog/uri/uri.js |  43.9KB |      43.9KB |
|                        cljs/test.cljs |  38.9KB |      21.1KB |
|                 goog/html/safehtml.js |  37.8KB |      37.8KB |
|   cljs/tools/reader/reader_types.cljs |  37.7KB |       8.9KB |
|                     goog/uri/utils.js |  36.6KB |      36.6KB |
|            cljs/tools/reader/edn.cljs |  35.2KB |      15.4KB |
|                     goog/math/long.js |  30.2KB |      30.2KB |
|                     goog/i18n/bidi.js |  29.2KB |      29.2KB |
| cljs/core/async/impl/ioc_helpers.cljs |  28.2KB |       4.6KB |
|    cljs/core/async/impl/channels.cljs |  25.7KB |       7.9KB |
|    cljs/tools/reader/impl/errors.cljs |  25.6KB |       7.1KB |
|                  goog/math/integer.js |  24.5KB |      24.5KB |
|                 goog/object/object.js |  22.1KB |      22.1KB |
|                     demo/browser.cljs |  21.7KB |       2.3KB |
|                      cljs/reader.cljs |  20.5KB |       7.2KB |
|                goog/html/safestyle.js |  20.2KB |      20.2KB |
|     cljs/tools/reader/impl/utils.cljs |  18.4KB |       2.5KB |
|                  goog/html/safeurl.js |  16.8KB |      16.8KB |
|           goog/useragent/useragent.js |  16.6KB |      16.6KB |
|                      goog/dom/safe.js |  16.4KB |      16.4KB |
|     cljs/core/async/impl/buffers.cljs |  16.3KB |       4.1KB |
|                   goog/dom/tagname.js |  15.9KB |      15.9KB |
|                     goog/dom/forms.js |  15.8KB |      15.8KB |
|       goog/html/trustedresourceurl.js |  15.2KB |      15.2KB |
|           goog/functions/functions.js |  14.8KB |      14.8KB |
|                   clojure/string.cljs |  14.7KB |       8.2KB |
|                     goog/math/math.js |  14.6KB |      14.6KB |
|                     goog/math/rect.js |  14.5KB |      14.5KB |
|                       shadow/api.cljs |  14.2KB |       3.6KB |
|      cljs/core/async/impl/timers.cljs |  13.9KB |       5.8KB |
|               goog/asserts/asserts.js |  13.6KB |      13.6KB |
|   cljs/core/async/impl/protocols.cljs |  13.0KB |       1.8KB |
|                   goog/structs/map.js |  12.9KB |      12.9KB |
|           goog/html/safestylesheet.js |  12.6KB |      12.6KB |
|                 goog/window/window.js |  12.6KB |      12.6KB |
|                   goog/dom/asserts.js |  11.7KB |      11.7KB |
|               goog/structs/structs.js |  11.7KB |      11.7KB |
|                      goog/math/box.js |  11.2KB |      11.2KB |
|        goog/labs/useragent/browser.js |  10.6KB |      10.6KB |
|                goog/async/nexttick.js |  10.3KB |      10.3KB |
|                 goog/dom/classlist.js |  10.0KB |      10.0KB |
|     goog/html/uncheckedconversions.js |   9.5KB |       9.5KB |
|   cljs/tools/reader/impl/commons.cljs |   9.3KB |       4.4KB |
|                      shadow/util.cljs |   8.8KB |       2.7KB |
|               goog/html/safescript.js |   8.6KB |       8.6KB |
|               goog/math/coordinate.js |   8.3KB |       8.3KB |
|   cljs/tools/reader/impl/inspect.cljs |   8.2KB |       2.7KB |
|        goog/html/legacyconversions.js |   7.7KB |       7.7KB |
|                  goog/string/const.js |   6.1KB |       6.1KB |
|                     goog/math/size.js |   6.1KB |       6.1KB |
|                     clojure/walk.cljs |   5.6KB |       3.5KB |
|      goog/debug/entrypointregistry.js |   5.5KB |       5.5KB |
|       goog/labs/useragent/platform.js |   5.0KB |       5.0KB |
|                  shadow/test/env.cljs |   4.7KB |       1.1KB |
|         goog/labs/useragent/engine.js |   4.7KB |       4.7KB |
|               goog/reflect/reflect.js |   4.6KB |       4.6KB |
|              goog/style/transition.js |   4.5KB |       4.5KB |
|           goog/labs/useragent/util.js |   4.3KB |       4.3KB |
|                        goog/fs/url.js |   3.3KB |       3.3KB |
|                          shadow/js.js |   3.0KB |       3.0KB |
|                    goog/dom/vendor.js |   2.8KB |       2.8KB |
|           goog/string/stringbuffer.js |   2.7KB |       2.7KB |
|            goog/dom/browserfeature.js |   2.4KB |       2.4KB |
|                 goog/dom/inputtype.js |   2.1KB |       2.1KB |
|    cljs/core/async/impl/dispatch.cljs |   2.0KB |       0.8KB |
|                   goog/debug/error.js |   1.8KB |       1.8KB |
|            goog/string/typedstring.js |   1.8KB |       1.8KB |
|                  goog/dom/nodetype.js |   1.4KB |       1.4KB |
|                      goog/dom/tags.js |   1.4KB |       1.4KB |
|                    goog/math/irect.js |   1.2KB |       1.2KB |
|                           demo/es6.js |   1.2KB |      382.0B |
|               goog/dom/htmlelement.js |   1.2KB |       1.2KB |
|               demo/browser_extra.cljs |  263.0B |      135.0B |
|                      demo/more-es6.js |  153.0B |       50.0B |
|                           demo/foo.js |  134.0B |      213.0B |
|                      demo/worker.cljs |   80.0B |      118.0B |
|                  demo/never_load.cljs |   75.0B |       87.0B |
|                 demo/always_load.cljs |   75.0B |       83.0B |
|                   demo/sm_before.cljs |   63.0B |       55.0B |
|          shadow/module/base/append.js |       0 |           0 |
|          shadow/module/demo/append.js |       0 |           0 |
|         shadow/module/extra/append.js |       0 |           0 |
|        shadow/module/worker/append.js |       0 |           0 |
```