### PR TITLE
Check that reload-namespaces is not nil

### DIFF
--- a/src/main/shadow/cljs/devtools/client/node.cljs
+++ b/src/main/shadow/cljs/devtools/client/node.cljs
@@ -59,7 +59,8 @@
   (try
     (doseq [{:keys [provides output-name] :as src} sources]
       (when (or (not (is-loaded? output-name))
-                (some reload-namespaces provides))
+                (and reload-namespaces 
+                     (some reload-namespaces provides)))
         (closure-import output-name)))
     (ws-msg {:type :repl/require-complete :id id})
 


### PR DESCRIPTION
Fixes the following error when trying to send code to running NodeJs repl when reloading is not enabled.

Feel free to delete this pull request if it is the wrong place to fix the problem.

```
repl/require failed TypeError: Cannot read property 'cljs$core$IFn$_invoke$arity$1' of null
    at /home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/cljs/core.cljs:4199:12
    at Object.cljs$core$some [as some] (/home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/cljs.core.js:14541:3)
    at /home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/shadow/cljs/devtools/client/node.cljs:62:18
    at Object.shadow$cljs$devtools$client$node$repl_require [as repl_require] (/home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/shadow.cljs.devtools.client.node.js:202:3)
    at shadow$cljs$devtools$client$node$process_message (/home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/shadow/cljs/devtools/client/node.cljs:110:6)
    at Object.shadow$cljs$devtools$client$env$process_ws_msg [as process_ws_msg] (/home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/shadow/cljs/devtools/client/env.cljs:125:10)
    at WebSocket.<anonymous> (/home/matthys/projects/mattsum/landingpages/.shadow-cljs/builds/node/dev/out/cljs-runtime/shadow/cljs/devtools/client/node.cljs:147:12)
    at WebSocket.emit (events.js:180:13)
    at Receiver._receiver.onmessage (/home/matthys/projects/mattsum/landingpages/node_modules/ws/lib/WebSocket.js:141:47)
    at Receiver.dataMessage (/home/matthys/projects/mattsum/landingpages/node_modules/ws/lib/Receiver.js:389:14)
```