### PR TITLE
Made disk write to cache async

### DIFF
--- a/src/main/shadow/build/compiler.clj
+++ b/src/main/shadow/build/compiler.clj
@@ -2,6 +2,7 @@
   (:require [clojure.spec.alpha :as s]
             [clojure.string :as str]
             [clojure.set :as set]
+            [clojure.core.async :refer [go]]
             [clojure.java.io :as io]
             [clojure.tools.reader.reader-types :as readers]
             [clojure.tools.reader :as reader]
@@ -583,9 +584,16 @@
                  :ns-speced-vars ns-speced-vars
                  :compiler-options cache-compiler-options}]
 
-            (io/make-parents cache-file)
-            (cache/write-file cache-file cache-data)
-
+            (go
+              (try
+                (io/make-parents cache-file)
+                (cache/write-file cache-file cache-data)
+                (catch Exception e
+                  (util/warn state {:type   :cache-error
+                                    :action :write
+                                    :ns     ns
+                                    :id     resource-id
+                                    :error  e}))))
             true))
         (catch Exception e
           (util/warn state {:type :cache-error


### PR DESCRIPTION
So, I noticed on verbose setting that cache writes on my machine (which is all solid state) were taking as long as individual file compiles. I made this change to the compiler and it almost halved my compile times.  I don't know the compiler well enough to know if this is bad news, but it seems like the worst that can happen is a very rare case where it needs to read the cache again before it is written.

So, not sure if this exact patch makes sense, but since I tried it and got good result I thought I'd pass it along.