### PR TITLE
Fix a missing rename from :exports-sym to :exports-var

### DIFF
--- a/src/main/shadow/build/targets/node_library.clj
+++ b/src/main/shadow/build/targets/node_library.clj
@@ -40,8 +40,8 @@
       #(contains? % :exports)
       :exports-fn
       #(contains? % :exports-fn)
-      :exports-sym
-      #(contains? % :exports-sym))
+      :exports-var
+      #(contains? % :exports-var))
     ))
 
 (defmethod config/target-spec :node-library [_]


### PR DESCRIPTION
Probably some leftover.