### PR TITLE
[Fix #300] Make sure make-source-excerpt never goes out of bound

### DIFF
--- a/src/main/shadow/build/warnings.clj
+++ b/src/main/shadow/build/warnings.clj
@@ -21,14 +21,17 @@
 
         make-source-excerpt
         (fn [line col]
-          (let [before
-                (Math/max 0 (- line excerpt-offset))
+          (let [line
+                (Math/max 0 (Math/min line (dec max-lines))) ;; too paranoid?
+
+                before
+                (Math/min (Math/max 0 (- line excerpt-offset)) (dec max-lines))
 
                 idx
-                (Math/max 0 (dec line))
+                (Math/min (Math/max 0 line) (dec max-lines))
 
                 after
-                (Math/min max-lines (+ line excerpt-offset))]
+                (Math/max 0 (Math/min (+ line excerpt-offset) (dec max-lines)))]
 
             {:start-idx before
              :before (subvec source-lines before idx)


### PR DESCRIPTION
This patch adds paranoid boundaries to the index calculations so that
`make-source-excerpt` never goes out of bound.