### PR TITLE
Implement :fn-map for azure target

### DIFF
--- a/src/main/shadow/build/resource.clj
+++ b/src/main/shadow/build/resource.clj
@@ -74,7 +74,7 @@
      ::deps]
     ))
 
-(defn valid-resource? [{:keys [resource-id] :as rc}]
+(defn valid-resource? [rc]
   ;; this is for asserts but the default error is basically useless
   ;; java.lang.AssertionError: Assert failed: (rc/valid-resource? src)
   ;; so it just explains since its for debugging anyways
@@ -115,5 +115,3 @@
     identity
     (fn [^String name]
       (str/replace name File/separatorChar \/))))
-
-


### PR DESCRIPTION
Very WIP, the configuration I am testing is:

```clojure
:az {:target :azure-fn
     :output-dir "out"
     :runtime-dir "shared"
     :fn-map {:init-store ep-cloud.init-store/http-handler
              :query-events ep-cloud.query-events/http-handler}}
```

And a lambda looks like:


```clojure
(defn
  ^{:azure/disabled false
    :azure/scriptFile "index.js"
    :azure/bindings
    [{:authLevel "function"
      :type "httpTrigger"
      :direction "in"
      :name "req"}
     {:type "http"
      :direction "out"
      :name "response"}]
    :doc "Initialize the event store.

  This function is idempotent, you can call it multiple times."}

  http-handler
  [^js ctx ^js request]
  ....
  )
```