### PR TITLE
Avoid munging the :azure-app dir names

### DIFF
--- a/src/main/shadow/build/targets/azure_app.clj
+++ b/src/main/shadow/build/targets/azure_app.clj
@@ -55,7 +55,7 @@
           fn-meta)
 
         output-dir
-        (io/file app-dir fn-id-s)
+        (io/file app-dir (-> fn-id name))
 
         fn-file
         (io/file output-dir "function.json")


### PR DESCRIPTION
Small fix, the folder name needs to match the keyword name in the function map.