### PR TITLE
fix watch* to use passed-in build-config

### DIFF
--- a/src/main/shadow/cljs/devtools/api.clj
+++ b/src/main/shadow/cljs/devtools/api.clj
@@ -156,9 +156,9 @@
          (util/stdout-dump verbose)
 
          build-config
-         (if (map? build-id)
-           build-id
-           (config/get-build! build-id))]
+         (if (map? build-config)
+           build-config
+           (config/get-build! build-config))]
 
      (-> (start-worker build-config opts)
          (worker/watch out true)


### PR DESCRIPTION
Currently if you pass in a config map to `watch*`, it is ignored except for its `:build-id` key which is used to read the config again. This patch would continue to allow `watch*` to accept _either_ a build-id or build-config map. An alternative would be to remove this part altogether so that `watch*` _requires_ a config map.