### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.7
+
+RUN apk update && apk add nodejs-npm openjdk8-jre
+
+RUN npm install -g yarn shadow-cljs


### PR DESCRIPTION
Builds light a docker image that comes with:
 - java
 - node
 - npm,
 - yarn 
 - shadow-cljs

Use case is places CI such as gitlab CI or other continuous deployment pipelines where you need a light and container with shadow-cljs. I looked for one in the docker hub but could not find one.
Based on alpine so the image is small.

An example image is here https://hub.docker.com/r/urbanslug/shadow-cljs/

With this you can publish an official shadow-cljs image.

Closes #334 