### PR TITLE
Use newer Buffer API instead of deprecated one

### DIFF
--- a/src/main/shadow/cljs/node_bootstrap.txt
+++ b/src/main/shadow/cljs/node_bootstrap.txt
@@ -56,7 +56,7 @@ var SHADOW_IMPORT = global.SHADOW_IMPORT = function(src) {
 global.SHADOW_NODE_EVAL = function(js, smJson) {
   if (smJson) {
     js += "\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,";
-    js += new Buffer(smJson).toString('base64');
+    js += Buffer.from(smJson).toString('base64');
   }
 
   // console.log(js);


### PR DESCRIPTION
Since Node v6, the Buffer() function and constructor calls have been
deprecated in favor of using Buffer.alloc(), Buffer.from(), etc.

Node 10 started printing a deprecation warning.

For more details see:
- https://github.com/nodejs/node/blob/master/doc/api/deprecations.md
- https://medium.com/@jasnell/node-js-buffer-api-changes-3c21f1048f97