### PR TITLE
[#371] Support file scheme for css reloading

### DIFF
--- a/src/main/shadow/cljs/devtools/client/browser.cljs
+++ b/src/main/shadow/cljs/devtools/client/browser.cljs
@@ -154,7 +154,8 @@
 ;; capture this once because the path may change via pushState
 (def ^goog page-load-uri
   (when js/goog.global.document
-    (goog.Uri/parse js/document.location.href)))
+    (let [uri (goog.Uri/parse js/document.location.href)]
+      (if (= (.getScheme uri) "file") (.setPath uri "/") uri))))
 
 (defn handle-asset-watch [{:keys [updates] :as msg}]
   (doseq [path updates
@@ -170,7 +171,7 @@
 
       (let [new-link
             (doto (.cloneNode node true)
-              (.setAttribute "href" (str path "?r=" (rand))))]
+              (.setAttribute "href" (str (.getPath node-uri) "#" (rand))))]
 
         (devtools-msg "load CSS" path)
         (gdom/insertSiblingAfter new-link node)


### PR DESCRIPTION
fixes #371 

Support for reloading css with file scheme. Fix css reloading in electron.

Tested with:
https://github.com/shadow-cljs/quickstart-browser
https://github.com/ahonn/shadow-electron-starter