### PR TITLE
To fix Issue #399

### DIFF
--- a/src/main/shadow/undertow.clj
+++ b/src/main/shadow/undertow.clj
@@ -139,6 +139,8 @@
             (.setFollowLinks true)
             ;; must not be nil, empty == followAll
             (.setSafePaths (into-array String []))
+            ;; handle both junction and symlink on windows, refer to SystemUtils in Apache commons-lang3
+            (.setCaseSensitive (not (.startsWith (System/getProperty "os.name") "Windows")))
             (.build))
 
         handler


### PR DESCRIPTION
To fix [Issue #399](https://github.com/thheller/shadow-cljs/issues/399).

[ Summary ]
Handle resources for both `junction` and `symlink` on windows.

[ Root Cause ]
After `shadow-cljs 2.6.15`, on windows,
`PathResourceManager.getResource(String)` will return `null` if the path is a `junction`,
it's because that `PathResourceManager.getSymlinkBase(String, Path)` returns `null`.

[ Solution ]
To solve this problem for both `junction` and `symlink`,
we may set the property `caseSensitive` of `PathResourceManager.Builder` to be `false` on windows.

[ Result ]
Test Cases(on windows):
1. `PathResourceManager.getSymlinkBase(String, Path)` will return `non-null` if the path is a `symlink`, and `PathResourceManager.getResource(String)` returns `non-null`.
2. `PathResourceManager.getResource(Path, String, Path, String)` will return `non-null` if the path is a `junction` and `caseSensitive` is `false`.

[ References ]
1. [“directory junction” vs “directory symbolic link”?](https://superuser.com/questions/343074/directory-junction-vs-directory-symbolic-link)
2. [commons-lang3-3.8.1-src.zip](http://www.trieuvan.com/apache//commons/lang/source/commons-lang3-3.8.1-src.zip)