### PR TITLE
Added managed dependencies to remove version ambiguity

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,10 @@
   ["-target" "1.8"
    "-source" "1.8"]
 
+  :managed-dependencies [[commons-codec "1.11"]
+                         [com.google.errorprone/error_prone_annotations "2.1.3"]
+                         [com.google.code.findbugs/jsr305 "3.0.2"]]
+
   :dependencies
   [[org.clojure/clojure "1.9.0"]
    ;; java9, not required for java8


### PR DESCRIPTION
Running `lein deps :tree` leads to "confusing dependencies" where dependency versions conflict. Since `shadow-cljs` is used a a library, these confusing dependencies also end up in projects using shadow.

Rather than using specific excludes, it's easier to set the transitive dependency versions using [`:managed-dependencies`](https://github.com/technomancy/leiningen/blob/master/doc/MANAGED_DEPS.md).

`lein deps :tree`:
```
Your branch is up to date with 'origin/master'.
Possibly confusing dependencies found:
[com.google.javascript/closure-compiler-unshaded "v20180910"] -> [com.google.errorprone/error_prone_annotations "2.0.18"]
 overrides
[com.google.javascript/closure-compiler-unshaded "v20180910"] -> [com.google.guava/guava "25.1-jre"] -> [com.google.errorprone/error_prone_annotations "2.1.3"]

Consider using these exclusions:
[com.google.javascript/closure-compiler-unshaded "v20180910" :exclusions [com.google.errorprone/error_prone_annotations]]

[com.google.javascript/closure-compiler-unshaded "v20180910"] -> [com.google.code.findbugs/jsr305 "3.0.1"]
 overrides
[com.google.javascript/closure-compiler-unshaded "v20180910"] -> [com.google.guava/guava "25.1-jre"] -> [com.google.code.findbugs/jsr305 "3.0.2"]

Consider using these exclusions:
[com.google.javascript/closure-compiler-unshaded "v20180910" :exclusions [com.google.code.findbugs/jsr305]]

[com.cognitect/transit-clj "0.8.313"] -> [com.cognitect/transit-java "0.8.337"] -> [commons-codec "1.10"]
 overrides
[ring/ring-core "1.7.0" :exclusions [clj-time]] -> [ring/ring-codec "1.1.1"] -> [commons-codec "1.11"]

Consider using these exclusions:
[ring/ring-core "1.7.0" :exclusions [commons-codec clj-time]]

...
```