### PR TITLE
Reload assets on both `:new` and `:mod` events

### DIFF
--- a/src/main/shadow/cljs/devtools/server/worker/impl.clj
+++ b/src/main/shadow/cljs/devtools/server/worker/impl.clj
@@ -830,7 +830,7 @@
 
         updates
         (->> updates
-             (filter #(= :mod (:event %)))
+             (filter #(contains? #{:mod :new} (:event %)))
              (map #(update % :name rc/normalize-name))
              (map #(str watch-path "/" (:name %)))
              (into []))]


### PR DESCRIPTION
Sometimes, file modifications will result in two events (`:del` followed by `:new`) instead of a single `:mod` event.
Previously, nothing would happen in these situations.
This commit modifies `do-asset-update` to perform updates on both `:new` and `:mod` events.

See #430 for some additional background on this issue.