### PR TITLE
prefetch{,Module} and preload{,Module}

### DIFF
--- a/src/main/shadow/loader.js
+++ b/src/main/shadow/loader.js
@@ -66,11 +66,11 @@ shadow.loader.load_multiple = function(ids, opt_userInitiated) {
 };
 
 shadow.loader.prefetch = function(id) {
-  shadow.loader.mm.prefetch(shadow.loader.string_id(id));
+  shadow.loader.mm.prefetchModule(shadow.loader.string_id(id));
 };
 
 shadow.loader.preload = function(id) {
-  return shadow.loader.mm.preload(shadow.loader.string_id(id));
+  return shadow.loader.mm.preloadModule(shadow.loader.string_id(id));
 };
 
 // FIXME: not sure these should always be exported


### PR DESCRIPTION
As per: https://github.com/google/closure-library/blob/2033d5d96aa3fe315fee1efd31086ce096d433a2/closure/goog/module/modulemanager.js#L395

I'm seeing runtime errors saying `shadow.loader.mm.prefetch` is not a function