### PR TITLE
specify utf-8 to prevent SyntaxError

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ The compilation will create the `public/js/main.js` we configured above (`:main`
 <!doctype html>
 <html>
   <head>
+    <meta charset="utf-8" />
     <title>acme frontend</title>
   </head>
   <body>


### PR DESCRIPTION
Not sure if this is best for everyone, but using Mac OS X, I get the following error if I don't specify the charset in the HTML header. 

This minor change to the sample HTML prevents the following error in the browser javascript console: 
```
bidi.js:276 Uncaught SyntaxError: Invalid regular expression: /[Ö‘-Û¯Ûº-à£¿â€�-��-�ï¬-ï·¿ï¹°-ï»¼]/: Range out of order in character class
    at new RegExp (<anonymous>)
    at bidi.js:276
```