### PR TITLE
Allows bootstrapping to work in web-workers

### DIFF
--- a/src/main/shadow/cljs/bootstrap/browser.cljs
+++ b/src/main/shadow/cljs/bootstrap/browser.cljs
@@ -34,13 +34,8 @@
             (callback data)
             ))))))
 
-(defn script-eval
-  "js/eval doesn't get optimized properly, this hack seems to do the trick"
-  [code]
-  (let [node (js/document.createElement "script")]
-    (.appendChild node (js/document.createTextNode code))
-    (js/document.body.appendChild node)
-    (js/document.body.removeChild node)))
+(defn script-eval [code]
+  (js/goog.globalEval code))
 
 (defn execute-load! [compile-state-ref {:keys [type text uri ns provides] :as load-info}]
   #_ (js/console.log "load" type ns load-info)


### PR DESCRIPTION
Talked about this in slack. I'm trying to do a bootstrapped web worker and ran into a problem with script-eval. This fixes the problem for me. I deployed a minimal example before this change and then after. (Check the console). I did also test locally and after this change bootstrapping with eval works outside web-workers as well.


https://shadow-bug.jimmyhmiller.now.sh/
https://shadow-bug-fixed.jimmyhmiller.now.sh/
Source: https://github.com/jimmyhmiller/PlayGround/tree/master/shadow-debug

Let me know if there is anything else you need from me for this. 
