### PR TITLE
Install transitive dependencies with an exact version

### DIFF
--- a/src/main/shadow/cljs/devtools/server/npm_deps.clj
+++ b/src/main/shadow/cljs/devtools/server/npm_deps.clj
@@ -136,9 +136,9 @@
         (or (get-in config [:node-modules :install-cmd])
             (case (guess-node-package-manager config)
               :yarn
-              ["yarn" "add"]
+              ["yarn" "add" "--exact"]
               :npm
-              ["npm" "install" "--save"]))
+              ["npm" "install" "--save" "--save-exact"]))
 
         full-cmd
         (fill-packages-placeholder install-cmd args)


### PR DESCRIPTION
As of [reagent 0.9.0-rc1](https://github.com/reagent-project/reagent/issues/449) react and react-dom transitive dependencies are provided via [reagent's deps.cljs](https://github.com/reagent-project/reagent/blob/master/src/deps.cljs) instead of via dependent projects such as [re-frame](https://github.com/Day8/re-frame/commit/7b0f36ce18a9fbe1ba4e6b7fe2d11fbe6132ae2c#diff-590103d510c2047cd1bb3d3c86590a04).

At the moment despite using react `"16.9.0"` in the `deps.cljs` an [unsafe semver version range](https://github.com/Day8/re-frame-10x/issues/248), which is npm's default, is saved as `"^16.8.0"`.

Therefore I suggest changing the default behaviour of shadow-cljs to always prefer exact versions over version ranges.