### PR TITLE
update expo keep awake for Expo 33+

### DIFF
--- a/src/main/shadow/expo/keep_awake.cljs
+++ b/src/main/shadow/expo/keep_awake.cljs
@@ -1,4 +1,4 @@
 (ns ^:dev/once shadow.expo.keep-awake
-  (:require ["expo" :as expo]))
+  (:require ["expo-keep-awake" :refer [activateKeepAwake]]))
 
-(.activate expo/KeepAwake)
+(activateKeepAwake)


### PR DESCRIPTION
Starting with Expo 33, most of the imports from the "expo" package were deprecated as Expo split their libraries into separate modules.  And with Expo 35 (released yesterday), those deprecated stubs have been removed and only the modular packages will work.

This PR simply updates the shadow.expo.keep-awake plugin to use the correct module (and in this case, the function name changed as well).

Note that because of the function name change, it will only work for Expo 33+.  HOWEVER, the Expo client now requires 33+ as a minimum, so it shouldn't be an issue.