### PR TITLE
Use :val instead of :msg and pr-str the :ns

### DIFF
--- a/src/main/shadow/cljs/devtools/server/prepl.clj
+++ b/src/main/shadow/cljs/devtools/server/prepl.clj
@@ -83,7 +83,7 @@
     ;; (send! {:tag :runtimes :runtimes runtimes})
 
     (if (empty? runtimes)
-      (send! {:tag :err :msg "No available JS runtimes!"})
+      (send! {:tag :err :val "No available JS runtimes!"})
       ;; work loop
       (let [session-id (str (UUID/randomUUID))
             session-ns 'cljs.user
@@ -99,7 +99,7 @@
           (alt!!
             server-close
             ([_]
-             (send! {:tag :err :msg "The server is shutting down."})
+             (send! {:tag :err :val "The server is shutting down."})
              :close)
 
             ;; input from tool
@@ -109,7 +109,7 @@
                (let [{:keys [error? ex source]} msg]
                  (cond
                    error?
-                   (do (send! {:tag :err :msg (str "Failed to read: " ex)})
+                   (do (send! {:tag :err :val (str "Failed to read: " ex)})
                        (recur loop-state))
 
                    (= ":repl/quit" source)
@@ -144,7 +144,7 @@
                        {::m/keys [printed-result form eval-ms]} msg]
                    ;; worst hack in history to prevent having to read-string the result
                    (send! {:tag :ret
-                           :ns session-ns
+                           :ns (pr-str session-ns)
                            :form form
                            :ms (or eval-ms 0)
                            :val printed-result})
@@ -152,19 +152,19 @@
 
                  ::m/session-out
                  (do (when (= session-id (::m/session-id msg))
-                       (send! {:tag :out :msg (::m/text msg)}))
+                       (send! {:tag :out :val (::m/text msg)}))
                      (recur loop-state))
 
                  ::m/session-err
                  (do (when (= session-id (::m/session-id msg))
-                       (send! {:tag :err :msg (::m/text msg)}))
+                       (send! {:tag :err :val (::m/text msg)}))
                      (recur loop-state))
 
                  ::m/runtime-disconnect
                  (if-not (= runtime-id (::m/runtime-id msg))
                    (recur loop-state)
                    ;; inform client and let loop end, ending in disconnect
-                   (send! {:tag :err :msg "The JS Runtime disconnected."}))
+                   (send! {:tag :err :val "The JS Runtime disconnected."}))
 
                  ;; mostly likely coming after disconnect on the browser reload
                  ;; FIXME: should disconnect not actually disconnect but rather just wait?


### PR DESCRIPTION
So I spotted a few discrepancies and I haven't fix them all yet but I thought I'd make a start on them.

## To Do

 * [ ] `(println "hello!")` yields `{:tag :out, :msg "hello!"}`, I've corrected `:msg` to `:val` but it's still missing the newline from the `println`.
 * [ ] `(throw (js/Error. "ohno"))` yields nothing when it should yield a `:ret` with the `Error->map` data in the `:val` slot and `:exception true`. The original ClojureScript prepl doesn't yet set this `:exception` flag like Clojure but I have a patch for that going into the next version.

## What I've done

 * Replaced usage of `:msg` with `:val`, prepl messages always use `:tag` and `:val`.
 * Wrapped the `:ns` value in `pr-str` so we don't end up with `:ns my.ns`, it should be `:ns "my.ns"`.

Here's an example interaction with a node prepl started by Propel:

```clojure
(+ 10 10)
{:tag :ret, :val "20", :ns "cljs.user", :ms 8, :form "(+ 10 10)"}
(println "hello!")
{:tag :out, :val "hello!\n"}
{:tag :ret, :val "nil", :ns "cljs.user", :ms 9, :form "(println \"hello!\")"}
(throw (js/Error. "ohno"))
{:tag :ret, :val "{:via [{:type clojure.lang.ExceptionInfo, :message \"Execution error (Error) at (<cljs repl>:1).\\nohno\\n\", :data {:type [... ELIDED BECAUSE HUGE ...]  e__6695__auto___9502;\\n}\"}}", :ns "cljs.user", :form "(throw (js/Error. \"ohno\"))"}
{:tag :err, :val "(node:26008) [DEP0097] DeprecationWarning: Using a domain property in MakeCallback is deprecated. Use the async_context variant of MakeCallback or the AsyncResource class instead.\n"}
```

I hope this is a good start. I can probably take a look at the other unresolved issues I mentioned (errors might just need hooking up from your event system?) but I think the `println` one will be trickier, I guess the newlines are being trimmed somewhere in the system.

That probably can't be fixed without changing things other than the prepl stuff which I'm reluctant to do I guess. Let me know what you think, I hope this is helpful and I'm happy to add more if I get some time :smile: