### PR TITLE
Provide descriptive error message on failed load-extern-properties

### DIFF
--- a/src/main/shadow/build/closure.clj
+++ b/src/main/shadow/build/closure.clj
@@ -930,7 +930,9 @@
           (into #{} (ShadowAccess/getExternProperties cc))]
 
       (when-not (.success result)
-        (throw (ex-info "externs trouble" {})))
+        (throw (ex-info
+                (str "Error processing externs:\n"
+                     (str/join "\n" (map #(.toString %) (.errors result)))) {})))
 
       (assoc state ::extern-properties extern-properties)
       )))


### PR DESCRIPTION
I encountered this error message and had to poker around in the source code to debug it and I thought a more descriptive message would have been nice.

### Before:

```
[:app] Compiling ...
[:app] Build failure:
externs trouble
{}
ExceptionInfo: externs trouble
        shadow.build.closure/load-extern-properties (NO_SOURCE_FILE:933)
        shadow.build.closure/load-extern-properties (NO_SOURCE_FILE:910)
        shadow.build.compiler/compile-cljs-sources (compiler.clj:1059)
```

### After:

```
> [:app] Compiling ...
[:app] Build failure:
Error processing externs:
JSC_PARSE_ERROR. Parse error. const variables must have an initializer at EXTERNS:src/externs.js line 1 : 24
{}
ExceptionInfo: Error processing externs:
JSC_PARSE_ERROR. Parse error. const variables must have an initializer at EXTERNS:src/externs.js line 1 : 24
        shadow.build.closure/load-extern-properties (NO_SOURCE_FILE:933)
        shadow.build.closure/load-extern-properties (NO_SOURCE_FILE:910)
        shadow.build.compiler/compile-cljs-sources (compiler.clj:1059)
```

`(.errors result)` is a list of `JSError` which you can see at https://github.com/google/closure-compiler/blob/master/src/com/google/javascript/jscomp/JSError.java

It's a shame the error message is duplicated in the terminal output. I couldn't figure out how to avoid that. But this commit doesn't add the duplication; it was duplicated before as well. 