### PR TITLE
Fix for symbol in --config-merge

### DIFF
--- a/src/main/shadow/build/api.clj
+++ b/src/main/shadow/build/api.clj
@@ -54,6 +54,9 @@
     (keyword? b)
     b
 
+    (symbol? b)
+    b
+
     :else
     (throw (ex-info "failed to merge config value" {:a a :b b}))
     ))


### PR DESCRIPTION
I ran `npx shadow-cljs release main --config-merge '{:main bar.core/main}'`, but got error
```
failed to merge config value
{:a foo.core/main, :b bar.core/main}
ExceptionInfo: failed to merge config value
        shadow.build.api/deep-merge (api.clj:58)
```

Because `bar.core/main` is symbol, but `deep-merge` don't support symbol.
I fixed it.