### PR TITLE
Lock down build-helper-maven-plugin version for pom.xml generation

### DIFF
--- a/src/main/shadow/cljs/npm/cli.cljs
+++ b/src/main/shadow/cljs/npm/cli.cljs
@@ -697,6 +697,7 @@
                                [:plugin
                                 [:groupId "org.codehaus.mojo"]
                                 [:artifactId "build-helper-maven-plugin"]
+                                [:version "3.1.0"]
                                 [:executions
                                  [:execution
                                   [:phase "generate-sources"]


### PR DESCRIPTION
Hi,

and thanks for a very fine project!

I recently tried to import a shadow-cljs pom.xml project on a new machine. IntelliJ started complaining that the project had an unresolved plugin `org.codehaus.mojo:build-helper-maven-plugin:<unknown>`.

This complaint only happens when this plugin has never been downloaded (due to the new machine/setup in this case). Manually adding a `<version>3.1.0</version>` fixed the problem.

To reproduce this issue, you may do something like this:

```bash
$ rm -rv $HOME/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin
removed '/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.jar.lastUpdated'
removed '/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.pom.lastUpdated'
removed directory '/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin'

# refresh a project inside IntelliJ, then check the .m2 folder:

$ find $HOME/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.jar.lastUpdated
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.pom.lastUpdated

# Edit pom.xml and explicitly state version number.
# Refresh the project again in IntelliJ (no errors this time).
# Then check the .m2 folder:

$ find $HOME/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0/build-helper-maven-plugin-3.1.0.pom.sha1
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0/build-helper-maven-plugin-3.1.0.jar.sha1
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0/_remote.repositories
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0/build-helper-maven-plugin-3.1.0.pom
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/3.1.0/build-helper-maven-plugin-3.1.0.jar
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.jar.lastUpdated
/home/ire/.m2/repository/org/codehaus/mojo/build-helper-maven-plugin/build-helper-maven-plugin-.pom.lastUpdated
```

This pull request fixes this issue by explicitly stating the version number `3.1.0`, which is the latest version.

Thanks and kind regards.