### PR TITLE
Add :build-notify config option.

### DIFF
--- a/src/main/shadow/build/targets/shared.clj
+++ b/src/main/shadow/build/targets/shared.clj
@@ -42,6 +42,8 @@
 
 (s/def ::before-load-async unquoted-qualified-symbol?)
 
+(s/def ::build-notify unquoted-qualified-symbol?)
+
 (s/def ::devtools-url non-empty-string?)
 
 (s/def ::use-document-host boolean?)
@@ -57,6 +59,7 @@
      ::after-load
      ::before-load
      ::before-load-async
+     ::build-notify
      ::use-document-host
      ::devtools-url]))
 


### PR DESCRIPTION
While developing React Native application with shadow-cljs there is no HUD showing build state like you see in web browser. In order to build HUD for React Native, app needs to know status of a build like "build started", "build completed", etc.

Introduce new config option `build-notify`. It accepts a symbol of a function that would be called on each build step.
Two arguments `build-status` (string) and `warnings` (js array) would be passed to that function. Build statuses are: `build-start`, `build-complete` and `build-failure`.
`warnings` is a js array with objects representing compilation warning, for example:
```
[{"column": 7, "file": "/path/to/file.cljs", "line": 165, "msg": "Use of undeclared Var my.ns/foo", "resource-id": ["resource", "my/ns/file.cljs"], "resource-name": "my/ns/file.cljs", "source-excerpt": {"after": [Array], "before": [Array], "line": "foo", "start-idx": 161}, "warning": "undeclared-var"}]
```

Example usage:
```clj
{:target :react-native
 {:devtools {:build-notify my.ns/build-notify}}
}

(ns my.ns)

(defn build-notify
 [build-status warnings]
 (case build-status
  "build-start" (on-start)
  "build-complete" (on-complete warnings)
  "build-failure" (on-failure)))
```