### PR TITLE
fix misplaced docstrings

### DIFF
--- a/src/main/shadow/cljs/devtools/api.clj
+++ b/src/main/shadow/cljs/devtools/api.clj
@@ -258,7 +258,7 @@
   (when-let [{:keys [proc-control] :as worker} (get-worker build-id)]
     (>!! proc-control {:type :runtime-kick :runtime-id runtime-id})))
 
-(defn repl-runtime-clear []
+(defn repl-runtime-clear
   "kick all registered runtimes that haven't responded to ping within 5sec
 
    only needed in cases where the runtime doesn't properly disconnect which

--- a/src/main/shadow/cljs/devtools/server/repl_system.clj
+++ b/src/main/shadow/cljs/devtools/server/repl_system.clj
@@ -114,12 +114,12 @@
     ))
 
 (defn tool-connect
-  [svc tool-id tool-in]
   "tool-in is messages coming from tools (potentially forwarded to runtimes)
    returns tool-out for messages to the connected tool
 
    tool-in closing means tool disconnected
    tool-out closing means its connection should end (eg. system shutdown)"
+  [svc tool-id tool-in]
 
   (let [{:keys [state-ref]} svc
 


### PR DESCRIPTION
A few docstrings are placed after the binding form in the source.