### PR TITLE
fix: npm-deps/get-major-java-version with loom

### DIFF
--- a/src/main/shadow/cljs/devtools/server/npm_deps.clj
+++ b/src/main/shadow/cljs/devtools/server/npm_deps.clj
@@ -9,17 +9,11 @@
   (:import (javax.script ScriptEngineManager ScriptEngine Invocable)))
 
 (defn get-major-java-version []
-  (let [java-version
-        (or (System/getProperty "java.vm.specification.version") ;; not sure this was always available
-            (System/getProperty "java.version"))
-        dot
-        (str/index-of java-version ".")
-
-        java-version
-        (if-not dot java-version (subs java-version 0 dot))]
-
-    ;; return 1 for 1.8, 1.9 which is fine ...
-    (Long/parseLong java-version)))
+  (->> ["java.vm.specification.version"
+        "java.version"]
+       (some #(System/getProperty %))
+       (re-find #"^\d+")
+       Long/parseLong))
 
 (defn make-engine* []
   (let [java-version (get-major-java-version)]


### PR DESCRIPTION
Fixes an issue where certain java builds could return trailing
characters (eg. the loom preview builds' "15-loom") causing the existing
parsing logic to fail.

The new implementation works by instead relying on the major version
number being at the start of the string and uses a regex to grab it.