### PR TITLE
feat: add graaljs based JS evaluation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -45,6 +45,9 @@
   ring/ring-core {:mvn/version "1.8.0" :exclusions [clj-time]}
   hawk {:mvn/version "0.2.11"}
 
+  org.graalvm.js/js {:mvn/version "20.1.0"}
+  org.graalvm.js/js-scriptengine {:mvn/version "20.1.0"}
+
   io.undertow/undertow-core
   {:mvn/version "2.0.30.Final"
    :exclusions

--- a/project.clj
+++ b/project.clj
@@ -51,6 +51,9 @@
    [thheller/shadow-util "0.7.0"]
    [thheller/shadow-client "1.3.3"]
 
+   [org.graalvm.js/js "20.1.0"]
+   [org.graalvm.js/js-scriptengine "20.1.0"]
+
    [io.undertow/undertow-core "2.1.1.Final"]
 
    [hiccup "1.0.5"]

--- a/src/main/shadow/cljs/devtools/server/npm_deps.clj
+++ b/src/main/shadow/cljs/devtools/server/npm_deps.clj
@@ -1,37 +1,15 @@
 (ns shadow.cljs.devtools.server.npm-deps
   "utility namespaces for installing npm deps found in deps.cljs files"
   (:require [clojure.edn :as edn]
-            [clojure.pprint :refer (pprint)]
             [clojure.string :as str]
             [clojure.java.io :as io]
             [clojure.data.json :as json]
             [shadow.cljs.devtools.server.util :as util])
-  (:import (javax.script ScriptEngineManager ScriptEngine Invocable)))
-
-(defn get-major-java-version []
-  (let [java-version
-        (or (System/getProperty "java.vm.specification.version") ;; not sure this was always available
-            (System/getProperty "java.version"))
-        dot
-        (str/index-of java-version ".")
-
-        java-version
-        (if-not dot java-version (subs java-version 0 dot))]
-
-    ;; return 1 for 1.8, 1.9 which is fine ...
-    (Long/parseLong java-version)))
-
-(defn make-engine* []
-  (let [java-version (get-major-java-version)]
-    (when (>= java-version 11)
-      (System/setProperty "nashorn.args" "--no-deprecation-warning")))
-
-  (-> (ScriptEngineManager.)
-      (.getEngineByName "nashorn")))
+  (:import (javax.script ScriptEngineManager)))
 
 (defn make-engine []
-  (let [engine
-        (make-engine*)
+  (let [engine (-> (ScriptEngineManager.)
+                   (.getEngineByName "JavaScript"))
 
         semver-js
         (slurp (io/resource "shadow/build/js/semver.js"))]

--- a/test/main/shadow/cljs/devtools/server/npm_deps_test.clj
+++ b/test/main/shadow/cljs/devtools/server/npm_deps_test.clj
@@ -1,0 +1,11 @@
+(ns shadow.cljs.devtools.server.npm-deps-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [shadow.cljs.devtools.server.npm-deps :as sut]))
+
+
+(deftest sever-intersects-test
+  (testing "smoke-test for JS interop"
+    (is (sut/semver-intersects "^1.0.0" "^1.1.0"))
+    (is (sut/semver-intersects "github:foo" "github:foo"))
+    (is (not (sut/semver-intersects ">=1.3.0" "1.2.0")))
+    (is (not (sut/semver-intersects "^2.0.0" "^1.1.0")))))


### PR DESCRIPTION
Switches to the graal JS implementation from nashorn.

Also adds some tests for the module so we have simple smoke tests as to
whether our semver.js is accurately loaded.

Tested on JDK 8 and JDK-15-loom preview builds.