### PR TITLE
Remove old link only after new one is loaded

### DIFF
--- a/src/main/shadow/cljs/devtools/client/browser.cljs
+++ b/src/main/shadow/cljs/devtools/client/browser.cljs
@@ -124,9 +124,9 @@
             (doto (.cloneNode node true)
               (.setAttribute "href" (str path-match "?r=" (rand))))]
 
+        (set! (.-onload new-link) #(gdom/removeNode node))
         (devtools-msg "load CSS" path-match)
         (gdom/insertSiblingAfter new-link node)
-        (gdom/removeNode node)
         ))))
 
 (defn global-eval [js]


### PR DESCRIPTION
Current implementation removes old link node just after inserting new one but before it is loaded. This results a blinking/flashing effect which is very annoying.