### PR TITLE
use the goog.global.location.protocol for get-base-url

### DIFF
--- a/src/main/shadow/cljs/devtools/client/env.cljs
+++ b/src/main/shadow/cljs/devtools/client/env.cljs
@@ -40,6 +40,8 @@
 
 (goog-define use-document-host true)
 
+(goog-define use-document-protocol true)
+
 (goog-define devtools-url "")
 
 (goog-define reload-strategy "optimized")
@@ -62,6 +64,13 @@
        :runtime_id runtime-id
        :ssl ssl})
 
+(defn get-server-protocol []
+  (if (and use-document-protocol
+           js/goog.global.location
+           (seq js/goog.global.location.protocol))
+    (str/replace js/goog.global.location.protocol ":" "")
+    (str "http" (when ssl "s"))))
+
 (defn get-server-host []
   (cond
     (and use-document-host
@@ -78,7 +87,7 @@
 (defn get-url-base []
   (if (seq devtools-url)
     devtools-url
-    (str "http" (when ssl "s") "://" (get-server-host) ":" server-port)))
+    (str (get-server-protocol) "://" (get-server-host) ":" server-port)))
 
 (defn get-ws-url-base []
   (-> (get-url-base)


### PR DESCRIPTION
Analog to the use of the location host to construct the base url in `client/env.cljs`, this changes uses the location procotol to choose between http(s) (respectivelly ws(s)).

I have added an `use-document-protocol` property; maybe it is not necessary and the `use-document-host` property can be renamed and reused. What do you think?

This would solve #496 without the need to add another option.

For instance, this is useful to test on an iPad: the repl/dev tools are running locally on my machine and a bastion host with nginx/letsencrypt is running in the cloud (allowing https connections from the iPad); thank to a SSH reverse tunnel, the requests are forwarded to the local dev tools. 