### PR TITLE
add space for readable error message

### DIFF
--- a/src/main/shadow/build/npm.clj
+++ b/src/main/shadow/build/npm.clj
@@ -184,7 +184,7 @@
     (when (and (seq entries)
                (not entry-file))
       (throw (ex-info
-               (str "package in " package-dir "specified entries but they were all missing")
+               (str "package in " package-dir " specified entries but they were all missing")
                {:tag ::missing-entries
                 :entries entries
                 :package-dir package-dir})))


### PR DESCRIPTION
directory name /foo/bazz and the word "specified" was concatenated

```
package in /foo/bazzspecified entries but they were all missing
```