### PR TITLE
WIP: fix worker-start-arg

### DIFF
--- a/src/main/shadow/cljs/devtools/server/supervisor.clj
+++ b/src/main/shadow/cljs/devtools/server/supervisor.clj
@@ -40,19 +40,19 @@
 
     (let [{:keys [proc-stop] :as proc}
           (worker/start
-            config
-            system-bus
-            executor
-            relay
-            clj-runtime
-            clj-obj-support
-            cache-root
-            http
-            classpath
-            npm
-            babel
-            build-config
-            cli-opts)]
+            {:config config
+             :system-bus system-bus
+             :executor executor
+             :relay relay
+             :clj-runtime clj-runtime
+             :clj-obj-support clj-obj-support
+             :cache-root cache-root
+             :http http
+             :classpath classpath
+             :npm npm
+             :babel babel
+             :build-config build-config
+             :cli-opts cli-opts})]
 
       (sys-bus/publish! system-bus ::m/supervisor {::m/worker-op :worker-start
                                                    ::m/build-id build-id})

--- a/src/main/shadow/cljs/devtools/server/supervisor.clj
+++ b/src/main/shadow/cljs/devtools/server/supervisor.clj
@@ -17,19 +17,7 @@
 (defonce super-lock (Object.))
 
 (defn start-worker
-  [{:keys [system-bus
-           workers-ref
-           executor
-           relay
-           clj-runtime
-           clj-obj-support
-           cache-root
-           http
-           classpath
-           npm
-           babel
-           config]
-    :as svc}
+  [{:keys [system-bus workers-ref] :as svc}
    {:keys [build-id] :as build-config}
    cli-opts]
   {:pre [(keyword? build-id)]}
@@ -39,20 +27,7 @@
       (throw (ex-info "already started" {:build-id build-id})))
 
     (let [{:keys [proc-stop] :as proc}
-          (worker/start
-            {:config config
-             :system-bus system-bus
-             :executor executor
-             :relay relay
-             :clj-runtime clj-runtime
-             :clj-obj-support clj-obj-support
-             :cache-root cache-root
-             :http http
-             :classpath classpath
-             :npm npm
-             :babel babel
-             :build-config build-config
-             :cli-opts cli-opts})]
+          (worker/start svc build-config cli-opts)]
 
       (sys-bus/publish! system-bus ::m/supervisor {::m/worker-op :worker-start
                                                    ::m/build-id build-id})

--- a/src/main/shadow/cljs/devtools/server/worker.clj
+++ b/src/main/shadow/cljs/devtools/server/worker.clj
@@ -97,27 +97,29 @@
 
 ;; FIXME: too many damn args, use a map instead!
 (defn start
-  [config
-   system-bus
-   executor
-   relay
-   clj-runtime
-   clj-obj-support
-   cache-root
-   http
-   classpath
-   npm
-   babel
-   {:keys [build-id] :as build-config}
-   cli-opts]
+  [{:keys [config
+           system-bus
+           executor relay
+           clj-runtime
+           clj-obj-support
+           cache-root
+           http
+           classpath
+           npm
+           babel
+           build-config
+           cli-opts]}]
   {:pre [(map? http)
          (map? build-config)
          (cp/service? classpath)
          (npm/service? npm)
          (babel/service? babel)
-         (keyword? build-id)]}
+         (contains? build-config :build-id)]}
 
-  (let [proc-id
+  (let [build-id
+        (:build-id build-config)
+
+        proc-id
         (str (UUID/randomUUID))
 
         _ (log/debug ::start {:build-id build-id :proc-id proc-id})

--- a/src/main/shadow/cljs/devtools/server/worker.clj
+++ b/src/main/shadow/cljs/devtools/server/worker.clj
@@ -95,7 +95,6 @@
 
 ;; SERVICE API
 
-;; FIXME: too many damn args, use a map instead!
 (defn start
   [{:keys [config
            system-bus
@@ -106,9 +105,9 @@
            http
            classpath
            npm
-           babel
-           build-config
-           cli-opts]}]
+           babel]}
+   {:keys [build-id] :as build-config}
+   cli-opts]
   {:pre [(map? http)
          (map? build-config)
          (cp/service? classpath)
@@ -116,10 +115,7 @@
          (babel/service? babel)
          (contains? build-config :build-id)]}
 
-  (let [build-id
-        (:build-id build-config)
-
-        proc-id
+  (let [proc-id
         (str (UUID/randomUUID))
 
         _ (log/debug ::start {:build-id build-id :proc-id proc-id})


### PR DESCRIPTION
I looked at this one and thought -- why not give it a try ...

Is there any way we can avoid creating the `build-id` in`let` -- L 119 in src/main/shadow/cljs/devtools/server/worker.clj?