### PR TITLE
Strip 'Secure' flag from cookies passing through dev-http proxy

### DIFF
--- a/src/main/shadow/cljs/devtools/server/dev_http.clj
+++ b/src/main/shadow/cljs/devtools/server/dev_http.clj
@@ -95,7 +95,8 @@
 
               ;; proxy-url but no proxy-predicate, proxy everything
               (not proxy-predicate)
-              [::undertow/proxy config]
+              [::undertow/strip-secure-cookies
+               [::undertow/proxy config]]
 
               ;; proxy-url + proxy-predicate, let predicate decide what to proxy
               ;; should be symbol pointing to function accepting undertow exchange and returning boolean
@@ -105,7 +106,8 @@
                 [::undertow/predicate-match
                  {:predicate-fn (fn [ex]
                                   (pred-var ex config))}
-                 [::undertow/proxy config]
+                 [::undertow/strip-secure-cookies
+                  [::undertow/proxy config]]
                  req-handler])
 
               :else

--- a/src/test/shadow/undertow_test.clj
+++ b/src/test/shadow/undertow_test.clj
@@ -1,0 +1,18 @@
+(ns shadow.undertow-test
+  (:require [clojure.test :refer :all]
+            [clojure.string :as str]
+            [shadow.undertow :as undertow])
+  (:import [io.undertow.util HeaderMap HttpString]))
+
+(def test-cookie "shadow-cljs/session=111222333; Max-Age=1295940; Path=/; HttpOnly; Secure; SameSite=Lax")
+
+(deftest unset-secure-cookie-check
+  (testing "Verifies that the unset-secure-cookie feature properly parses cookie strings"
+    (let [headers
+          (doto (HeaderMap.)
+            (.put (HttpString. "set-cookie") test-cookie))]
+      (is (str/includes? test-cookie "Secure;"))
+      (undertow/unset-secure-cookie headers)
+      (let [cookie (.get headers "set-cookie" 0)]
+        (is (str/includes? cookie "HttpOnly;"))
+        (is (not (str/includes? cookie "Secure;")))))))


### PR DESCRIPTION
Developers using the dev-proxy with http against an https backend may
have trouble if the backend submits cookies with the 'Secure' flag set.
Certain browsers, such as Chrome, will balk at cookies with 'Secure' set
that arrive via http.  This patch enables this type of flow to proceed
by removing the Secure token as it passes through the dev-proxy.

Signed-off-by: Greg Haskins <greg@manetu.com>