### PR TITLE
karma: If a test fails with exception, print the stacktrace

### DIFF
--- a/src/main/shadow/test/karma.cljs
+++ b/src/main/shadow/test/karma.cljs
@@ -48,15 +48,18 @@
       "FAIL in   " (ct/testing-vars-str result) "\n"
       (when-not (s/blank? testing-contexts-str)
         (str "\"" testing-contexts-str "\"\n"))
-      (if (and (seq? expected)
-               (seq? actual))
-        (str
-          "expected: " (format-fn indentation expected) "\n"
-          "  actual: " (format-fn indentation (second actual)) "\n"
-          (when-let [diff (format-diff indentation expected (second actual))]
-            (str "    diff: " diff "\n")))
-        (str
-          expected " failed with " actual "\n"))
+      (cond
+        (and (seq? expected)
+             (seq? actual))
+          (str
+                "expected: " (format-fn indentation expected) "\n"
+                "  actual: " (format-fn indentation (second actual)) "\n"
+                (when-let [diff (format-diff indentation expected (second actual))]
+                  (str "    diff: " diff "\n")))
+        (.hasOwnProperty actual "stack")
+          (str "Exception: " (.-stack actual))                  
+        :else
+          (str expected " failed with " actual "\n"))
       (when message
         (str " message: " (indent indentation message) "\n")))))
 


### PR DESCRIPTION
Normally all you get is something like `Error: No protocol method ISwap.-swap! defined for type null` which isn't very helpful. There's still the problem of source maps for the exceptions, but at least this way you've got a trace.

This relies on the existence of the non-standard [`stack`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/stack) attribute, but if it's missing in the particular browser will just fallback to the old behaviour.