### PR TITLE
Add a script to build aot jar

### DIFF
--- a/build-aot-jar.sh
+++ b/build-aot-jar.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if ! [[ -e ../shadow-experiments/README.md ]]; then
+    echo "Please setup ../shadow-experiments/ first."
+    echo "  cd .."
+    echo "  git clone git@github.com:thheller/shadow-experiments.git"
+    exit 1
+fi
+
+pushd packages/babel-worker
+yarn
+popd
+
+pushd packages/create-cljs-project
+yarn
+popd
+
+pushd packages/shadow-cljs
+yarn
+popd
+
+pushd packages/ui
+yarn
+popd
+
+./build-all.sh
+
+mkdir -p src/ui-release/shadow/cljs/dist/
+pushd packages/babel-worker
+yarn build
+popd
+
+lein jar
+
+# Deploy the jar to maven cache:
+# cp -p ./target/aot/shadow-cljs-2.11.18-aot.jar ~/.m2/repository/thheller/shadow-cljs/2.11.18/

--- a/packages/babel-worker/package.json
+++ b/packages/babel-worker/package.json
@@ -11,8 +11,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@babel/core": "^7.7.2",
-    "@babel/preset-env": "^7.7.1",
-    "@zeit/ncc": "^0.20.5"
+    "@babel/core": "7.7.2",
+    "@babel/preset-env": "7.7.1",
+    "@vercel/ncc": "^0.27.0",
+    "core-js-compat": "3.1.1"
   }
 }

--- a/src/main/shadow/cljs/npm/babel_worker.cljs
+++ b/src/main/shadow/cljs/npm/babel_worker.cljs
@@ -45,6 +45,8 @@
      }))
 
 (defn process-request [line]
+  ;; (.. js/process -stderr (write "got a line"))
+  ;; (.. js/process -stderr (write line))
   (let [req
         (read-string line)
 

--- a/src/main/shadow/cljs/npm/babel_worker.cljs
+++ b/src/main/shadow/cljs/npm/babel_worker.cljs
@@ -45,8 +45,6 @@
      }))
 
 (defn process-request [line]
-  ;; (.. js/process -stderr (write "got a line"))
-  ;; (.. js/process -stderr (write line))
   (let [req
         (read-string line)
 


### PR DESCRIPTION
I noticed that latest shadow-cljs release removed use of hawk and uses the native fs watcher of JVM, which takes about 2 seconds to trigger a reload on my machine (macos 10.15 catalina, not upgraded to big sur yet). So I want to revert that change on top the 2.11.18 and rebuild the jar.

Shadow-cljs is quite complex project, and I can't find any document or step-by-step guide to build shadow-cljs from source. With quite some tweaking and trial & error, I finally got a script that seems to work.  

I guess this could be helpful to others too.
