### PR TITLE
Specify encoding for transit-str

### DIFF
--- a/src/main/shadow/cljs/devtools/server/common.clj
+++ b/src/main/shadow/cljs/devtools/server/common.clj
@@ -61,7 +61,7 @@
               w (transit/writer out :json)]
           (try
             (transit/write w data)
-            (.toString out)
+            (.toString out "UTF-8")
             (catch Exception e
               (log/warn-ex e ::transit-str-failed {:data data})
               (throw e))))))


### PR DESCRIPTION
Hello,
I was having a strange issue where multibyte characters would display correctly on page load, only to have their encoding messed up if the file that contained them was hot reloaded. I took a look through the code and eventually determined that server messages were changing their encoding right before being sent. The fix seems as simple as specifying a character set for the transit string, so that's what I've done, utf-8 being the natural choice. Otherwise, encoding is apparently left up to the local JVM's default character set, a design which serves the dual purpose of overriding toString, and punishing developers for hubris.