### PR TITLE
use a faster file watching mechanism

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -43,7 +43,8 @@
   hiccup/hiccup {:mvn/version "1.0.5"}
 
   ring/ring-core {:mvn/version "1.8.0" :exclusions [clj-time/clj-time]}
-  hawk/hawk {:mvn/version "0.2.11"}
+  ;;hawk/hawk {:mvn/version "0.2.11"}
+  com.nextjournal/beholder {:mvn/version "1.0.0"}
 
   io.undertow/undertow-core
   {:mvn/version "2.0.30.Final"

--- a/project.clj
+++ b/project.clj
@@ -75,6 +75,8 @@
    ;; for pathom
    [org.clojure/test.check "1.1.0"]
 
+   [com.nextjournal/beholder "1.0.0"]
+
    [thheller/shadow-cljsjs "0.0.22"]]
 
   :source-paths

--- a/src/main/shadow/cljs/devtools/server/fs_watch.clj
+++ b/src/main/shadow/cljs/devtools/server/fs_watch.clj
@@ -37,7 +37,7 @@
         watcher
         (apply beholder/watch
                (fn file-changed [{:keys [type path] :as event}]
-                 (let [file (io/file path)
+                 (let [file (.toFile path)
                        name (.getName file)
                        dir (-> file (.getAbsoluteFile) (.getParent))]
                    ;; ignore empty files

--- a/src/main/shadow/cljs/devtools/server/fs_watch_previous.clj
+++ b/src/main/shadow/cljs/devtools/server/fs_watch_previous.clj
@@ -1,0 +1,83 @@
+(ns shadow.cljs.devtools.server.fs-watch-previous
+  (:require [shadow.build.api :as cljs]
+            [clojure.core.async :as async :refer (alt!! thread >!!)]
+            [shadow.cljs.devtools.server.util :as util]
+            [shadow.cljs.devtools.server.system-bus :as system-bus]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [shadow.build.resource :as rc])
+  (:import (shadow.util FileWatcher)
+           (java.io File)))
+
+(defn service? [x]
+  (and (map? x)
+       (::service x)))
+
+(defn poll-changes [{:keys [dir ^FileWatcher watcher]}]
+  (let [changes (.pollForChanges watcher)]
+    (when (seq changes)
+      (->> changes
+           (map (fn [[name event]]
+                  {:dir dir
+                   :name (rc/normalize-name name)
+                   :ext (when-let [x (str/last-index-of name ".")]
+                          (subs name (inc x)))
+                   :file (io/file dir name)
+                   :event event}))
+           ;; ignore empty files
+           (remove (fn [{:keys [event ^File file] :as x}]
+                     (and (not= event :del)
+                          (zero? (.length file)))))
+           ))))
+
+(defn watch-loop
+  [watch-dirs control publish-fn]
+
+  (loop []
+    (alt!!
+      control
+      ([_]
+       :terminated)
+
+      (async/timeout 500)
+      ([_]
+       (let [fs-updates
+             (->> watch-dirs
+                  (mapcat poll-changes)
+                  (into []))]
+
+         (when (seq fs-updates)
+           (publish-fn fs-updates))
+
+         (recur)))))
+
+  ;; shut down watchers when loop ends
+  (doseq [{:keys [^FileWatcher watcher]} watch-dirs]
+    (.close watcher))
+
+  ::shutdown-complete)
+
+(defn start [config directories file-exts publish-fn]
+  {:pre [(every? #(instance? File %) directories)
+         (coll? file-exts)
+         (every? string? file-exts)]}
+  (let [control
+        (async/chan)
+
+        watch-dirs
+        (->> directories
+             (map (fn [^File dir]
+                    {:dir dir
+                     :watcher (FileWatcher/create dir (vec file-exts))}))
+             (into []))]
+
+    {::service true
+     :control control
+     :watch-dirs watch-dirs
+     :thread (thread (watch-loop watch-dirs control publish-fn))}))
+
+(defn stop [{:keys [control thread] :as svc}]
+  {:pre [(service? svc)]}
+  (async/close! control)
+  (async/<!! thread))
+

--- a/src/repl/shadow/cljs/watch_test.clj
+++ b/src/repl/shadow/cljs/watch_test.clj
@@ -2,24 +2,60 @@
   (:require
     [clojure.test :refer (is deftest)]
     [clojure.java.io :as io]
-    [shadow.cljs.devtools.server.fs-watch :as fs]))
+    [shadow.cljs.devtools.server.fs-watch :as fs-watch]
+    [shadow.cljs.devtools.server.fs-watch-previous :as fs-watch-previous]))
 
+(deftest watch-performance
+  (add-tap println)
+  (let [base-dir (io/file "tmp" "fs-watch")
+        test-file (doto (io/file base-dir "foo.txt")
+                    (io/make-parents))
+        start (atom nil)
+        report (fn [label _event]
+                 (locking *out*
+                   (tap> (str "    " label ": " (- (System/currentTimeMillis) @start) "ms"))))
+        fs (fs-watch/start {} [base-dir] #{"txt"}
+                           #(report "new-watch" %))
+        fsp (fs-watch-previous/start {} [base-dir] #{"txt"}
+                                     #(report "previous-watch" %))]
+    (dotimes [i 10]
+      (reset! start (System/currentTimeMillis))
+      (tap> (str "Write" i ":"))
+      (spit test-file (str i))
+      (Thread/sleep 3500))
 
-(comment
-  (def watcher
-    (fs-jvm/start {}
-      [(io/file "tmp" "watch")]
-      #{"test"}
-      prn
-      ))
+    (fs-watch/stop fs)
+    (fs-watch-previous/stop fsp)))
 
-  (fs-jvm/stop watcher)
-
-  (def w-hawk
-    (fs-hawk/start {}
-      [(io/file "tmp" "watch")]
-      #{"test"}
-      prn
-      ))
-
-  (fs-hawk/stop w-hawk))
+;;;; Test output on MacOS BigSur
+;;Running shadow.cljs.watch-test/watch-performance
+;Write0:
+;    new-watch: 13ms
+;    previous-watch: 1029ms
+;Write1:
+;    new-watch: 13ms
+;    previous-watch: 1552ms
+;Write2:
+;    new-watch: 13ms
+;    previous-watch: 2072ms
+;Write3:
+;    new-watch: 12ms
+;    previous-watch: 587ms
+;Write4:
+;    new-watch: 13ms
+;    previous-watch: 1110ms
+;Write5:
+;    new-watch: 13ms
+;    previous-watch: 1645ms
+;Write6:
+;    new-watch: 12ms
+;    previous-watch: 2179ms
+;Write7:
+;    new-watch: 12ms
+;    previous-watch: 694ms
+;Write8:
+;    new-watch: 11ms
+;    previous-watch: 1213ms
+;Write9:
+;    new-watch: 13ms
+;    previous-watch: 1741ms


### PR DESCRIPTION
** do not merge until tested **

In theory, this approach should be faster to detect changes.

See
https://github.com/nextjournal/beholder
https://github.com/gmethvin/directory-watcher

I haven't tested this beyond the instructions in CONTRIBUTING.md because I'm not sure how to. I'd be very happy to do so with a little instruction on how to proceed. I was hoping to be able to edit a file and time the reload speed but I'm not sure how to make an example project depend upon the development version. I did the getting started `acme-app` but didn't see how to change the dependency to development.

I have tested the theory as well as I can by comparing beholder/directory-watcher against polling methods and it does perform much better, so I'm hopeful.
