### PR TITLE
added `,' to PS list of escape chars.

### DIFF
--- a/src/main/shadow/cljs/npm/cli.cljs
+++ b/src/main/shadow/cljs/npm/cli.cljs
@@ -379,6 +379,7 @@
 (defn powershell-escape [s]
   (-> s
       (str/replace " " "` ")
+      (str/replace "," "`,")
       (str/replace "{" "`{")
       (str/replace "}" "`}")
       (str/replace \" "`\"`\"")))


### PR DESCRIPTION
Patch for #930, adds `,` to the `powershell-escape` list, so that any commas generate by the `pr-str` command for the argument to`-Sdeps` are escaped.

The command now works as expected:
```
npx.cmd shadow-cljs -d nrepl/nrepl:0.8.3 -d cider/piggieback:0.5.2 server
shadow-cljs - config: issue-shadow-cljs-deps-ps\shadow-cljs.edn
shadow-cljs - starting via "clojure"
shadow-cljs - server version: 2.15.8 running at http://localhost:9630
shadow-cljs - nREPL server started on port 56204
```

I've noticed there are some more special characters mentioned over at [SS64](https://ss64.com/ps/syntax-esc.html), perhaps now is a good time as any to add them (not sure how to test any side effects though with existing usage)?:

```
Using the Escape character to avoid special meaning.

   ``  To avoid using a Grave-accent as the escape character
   `#  To avoid using # to create a comment
   `'  To avoid using ' to delimit a string
   `"  To avoid using " to delimit a string
```
vs what we currently have:
*src/main/shadow/cljs/npm/cli.cljs*:
```clojure
(defn powershell-escape [s]
  (-> s
      (str/replace " " "` ")
      (str/replace "," "`,")
      (str/replace "{" "`{")
      (str/replace "}" "`}")
      (str/replace \" "`\"`\"")))
```

Thanks

