### PR TITLE
Fix  Unicode comm issue between server and (Browser) REPL on MS-Windows

### DIFF
--- a/src/main/shadow/cljs/devtools/server/common.clj
+++ b/src/main/shadow/cljs/devtools/server/common.clj
@@ -41,7 +41,7 @@
       (fn [in]
         (let [r (transit/reader
                   (if (string? in)
-                    (ByteArrayInputStream. (.getBytes in))
+                    (ByteArrayInputStream. (.getBytes in "UTF-8"))
                     in)
                   :json)]
           (try
@@ -61,7 +61,7 @@
               w (transit/writer out :json)]
           (try
             (transit/write w data)
-            (.toString out)
+            (.toString out "UTF-8")
             (catch Exception e
               (log/warn-ex e ::transit-str-failed {:data data})
               (throw e))))))


### PR DESCRIPTION
Hi,

could you please consider a fix for issue #946. 

The transit `:json` mode that is used for the server to exchange data with the browser REPL, expects its byte arrays to contain Unicode characters (I believe this is in accordance with the JSON specification), but shadow does not explicitly specify an encoding when converting from `String`s to `ByteArray`s or vice versa. The default Java encoding is used instead, which on MS-Windows is windows-1252.

This means that the server encodes Unicode `String`s to bytes with windows-1252, while it reads binary data from the clients (which suppose to be Unicode) as windows-1252 bytes, causing unspecified behavior such as transit throwing exceptions.

The patch explicitly sets the `String`<->`BinaryArray` encoding for transit to be UTF-8. A test has been included to confirm Unicode messages can round-trip in transit.

An alternative and/or perhaps complementary solution would be to explicitly set the default encoding on MS-Windows to UTF-8 (as a jvm option `-Dfile.encoding=UTF-8` perhaps in `src/main/shadow/cljs/npm/cli.cljs`-- the default encoding can only be changed at JVM startup). Though, the server is not necessarily only invoked by the cli script, thus this solution by itself is not universal?

Thanks!