### PR TITLE
clear hud errors after compile success

### DIFF
--- a/src/main/shadow/cljs/devtools/client/browser.cljs
+++ b/src/main/shadow/cljs/devtools/client/browser.cljs
@@ -300,6 +300,7 @@
             (fn [msg]
               ;; (js/console.log "cljs-build-complete" msg)
               (let [msg (env/add-warnings-to-info msg)]
+                (hud/connection-error-clear!)
                 (hud/hud-warnings msg)
                 (handle-build-complete runtime msg)
                 (env/run-custom-notify! (assoc msg :type :build-complete))))


### PR DESCRIPTION
To reproduce: in any shadow-cljs project, in any .cljs file, add a line `(js/eval "a =")`. After reloading, which shadow-cljs would show an error:

<img width="830" alt="Screen Shot 2021-10-13 at 10 28 11 AM" src="https://user-images.githubusercontent.com/30067222/137056666-0e45e20c-082f-4cf6-9ac4-8f9606f41cef.png">

But after removing that line, the error would not be cleared. 

This patch should have that fixed.
