### PR TITLE
for dev-http servers, initially use config passed to start shadow ser…

### DIFF
--- a/src/main/shadow/cljs/devtools/server/dev_http.clj
+++ b/src/main/shadow/cljs/devtools/server/dev_http.clj
@@ -400,7 +400,7 @@
 
 (defn start-servers [sys-bus config ssl-context out]
   (let [configs
-        (get-server-configs)
+        (transform-server-configs config)
 
         servers
         (into [] (map #(start-build-server sys-bus config ssl-context out %)) configs)]


### PR DESCRIPTION
…ver, rather than file.