### PR TITLE
make data_readers.cljc work as they do in clojurescript

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -38,13 +38,13 @@
   org.clojure/core.async {:mvn/version "1.5.648"}
 
   org.clojure/clojurescript
-  {:mvn/version "1.11.4"
+  {:mvn/version "1.11.51"
    :exclusions
    [com.google.javascript/closure-compiler-unshaded
     org.clojure/google-closure-library
     org.clojure/google-closure-library-third-party]}
 
-  com.google.javascript/closure-compiler-unshaded {:mvn/version "v20220301"}
+  com.google.javascript/closure-compiler-unshaded {:mvn/version "v20220502"}
 
   org.clojure/google-closure-library {:mvn/version "0.0-20211011-0726fdeb"}
   org.clojure/google-closure-library-third-party {:mvn/version "0.0-20211011-0726fdeb"}

--- a/src/main/shadow/build.clj
+++ b/src/main/shadow/build.clj
@@ -476,7 +476,14 @@
                 (log/warn-ex e ::data-reader-load-ex {:tag tag :read-fn read-fn-sym :read-ns read-ns})))))
 
         (-> state
-            (update-in [:compiler-env :cljs.analyzer/data-readers] merge data-readers)
+            (update-in [:compiler-env :cljs.analyzer/data-readers] merge
+              (->> data-readers
+                   ; assoc meta as per cljs.analyzer/load-data-readers
+                   (keep (fn [[tag reader-fn]]
+                           (when-let [f (-> reader-fn find-var var-get
+                                            (with-meta {:sym reader-fn}))]
+                             [tag f])))
+                   (into {})))
             (assoc ::data-readers-loaded true))))))
 
 (defn compile

--- a/src/main/shadow/build/compiler.clj
+++ b/src/main/shadow/build/compiler.clj
@@ -303,7 +303,8 @@
                       resource-name
 
                       reader/*data-readers*
-                      tags/*cljs-data-readers*
+                      (merge tags/*cljs-data-readers*
+                        (ana/load-data-readers))
 
                       reader/*alias-map*
                       reader-aliases

--- a/src/main/shadow/cljs/repl.clj
+++ b/src/main/shadow/cljs/repl.clj
@@ -542,7 +542,8 @@
                     name
 
                     reader/*data-readers*
-                    tags/*cljs-data-readers*
+                    (merge tags/*cljs-data-readers*
+                      (ana/load-data-readers))
 
                     ;; ana/resolve-symbol accesses the env
                     ;; don't need with-compiler-env since it's read only and doesn't side effect


### PR DESCRIPTION
this keeps the custom log messages shadow had for data_readers but brings it up to date with clojurescript. 

I'm not sure how to run shadow's tests though?