### PR TITLE
Polyfill inherits

### DIFF
--- a/src/main/shadow/build/closure.clj
+++ b/src/main/shadow/build/closure.clj
@@ -2582,7 +2582,8 @@
                 "util/findinternal"
                 "util/defines"
                 "util/global"
-                "es6/array/find"})
+                "es6/array/find"
+                "es6/util/inherits"})
             goog-injected-libs
             shadow-js-injected-libs
             classpath-js-injected-libs

--- a/src/main/shadow/build/targets/react_native.clj
+++ b/src/main/shadow/build/targets/react_native.clj
@@ -257,7 +257,8 @@
 
                (let [{:keys [polyfill-js]} state]
                  (when (and (or goog-base web-worker) (seq polyfill-js))
-                   (str "\n" polyfill-js)))
+                   (str "\n" polyfill-js
+                        "\nglobal.$jscomp = $jscomp;")))
 
                (slurp (io/resource "shadow/boot/react-native.js"))
                "\n\n"


### PR DESCRIPTION
## What is this PR addressing?

The current version of ShadowCLJS (`2.19.6`) and ClojureScript (`1.11.60`) has a bug when compiling with `:output-feature-set :es5`. The resulting JS is producing one of the following errors, when executed (depending on target):
- `ReferenceError: $jscomp is not defined`
- `TypeError: $jscomp.inherits is not a function`
- `Property '$jscomp' doesn't exist`

I've put up a repository for demonstration: https://github.com/stigi/clojurescript-es5-issue

## Context

In a recent change [`goog.struct.map`](https://github.com/google/closure-library/blob/99a2e56fd143a71ad16381c12017e53989e84b28/closure/goog/structs/map.js#L24) started depending on `goog.iter.es6`. That one itself is implemented using [ES6 classes with inheritance](https://github.com/google/closure-library/blob/99a2e56fd143a71ad16381c12017e53989e84b28/closure/goog/iter/es6.js#L116) and therefore requires the [`es6/util/inherits`](https://github.com/google/closure-compiler/blob/2d6513d7adcdb76080b8e9d51e93737b7226aaf9/src/com/google/javascript/jscomp/js/es6/util/inherits.js#L57) polyfill which was missing.

As a workaround one could add that polyfill using the `:force-library-injection #{"es6/util/inherits"}` compiler option. This worked in my tests when using the `node` target, but didn't when using `react-native` as a target.

For `react-native` to work, I also had to make `$jscomp` available as `global.$jscomp`, similar to how it's [done in the `node` target](https://github.com/thheller/shadow-cljs/blob/d6e14905022b719d2e240646417f53d9ee452e4d/src/main/shadow/build/node.clj#L187:L188). The reason for this is that shadow is using eval to load closure modules, and eval only knows the global scope.


## Considerations

We might have to update other targets (i.e. `browser`) as well to have `global.$jscomp`.


## Meta

Discussed in [Clojurians Slack](https://clojurians.slack.com/archives/C6N245JGG/p1658307784184749)