### PR TITLE
docs(README): fix for broken link to Boodle project (accounting SPA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Please refer to the [User Manual](https://shadow-cljs.github.io/docs/UsersGuide.
 - [quangv/shadow-re-frame-simple-example](https://github.com/quangv/shadow-re-frame-simple-example) - a simple re-frame + shadow-cljs example.
 - [CryptoTwittos](https://github.com/teawaterwire/cryptotwittos) - reagent, re-frame, web3
 - [loganpowell/shadow-proto-starter](https://github.com/loganpowell/shadow-proto-starter) - shadow-cljs, Atom, Proto-REPL, node.js library
-- [manuel-uberti/boodle](https://github.com/manuel-uberti/boodle) - re-frame based Accounting SPA with `deps.edn` based backend
+- [manuel-uberti/boodle](https://sr.ht/~manuel-uberti/boodle/) - re-frame based Accounting SPA with `deps.edn` based backend
 - [shadow-cljs-kitchen-async-puppeteer](https://github.com/iku000888/shadow-cljs-kitchen-async-puppeteer) - Automated browser test with puppeteer and cljs.test, built with shadow-cljs
 - [baskeboler/cljs-karaoke-client](https://github.com/baskeboler/cljs-karaoke-client) - web karaoke player using shadow-cljs + reagent + re-frame + re-frame-10x + re-frame-async-flow-fx + build hooks for minifying css and generating seo pages ([Demo](https://karaoke-player.netlify.app/songs/Rolling%20Stones-all%20over%20now%20rolling%20stones.html))
 - [flexsurfer/ClojureRNProject](https://github.com/flexsurfer/ClojureRNProject) - simple React Native application with ClojureScript, re-frame and react navigation v5


### PR DESCRIPTION

(Aside: as a reader of the README, one difficulty I have is: I can't tell which sample projects use Node as a back-end. Of course, this comment is unrelated to the broken link!)