### PR TITLE
Fixes thheller/shadow-cljs#1081

### DIFF
--- a/packages/shadow-cljs-jar/project.clj
+++ b/packages/shadow-cljs-jar/project.clj
@@ -8,7 +8,7 @@
   [[org.clojure/clojure "1.10.1"]
    [com.cemerick/pomegranate "1.1.0"]
    [org.slf4j/slf4j-nop "1.7.30"]
-   [s3-wagon-private "1.3.3"
+   [s3-wagon-private "1.3.5"
     :exclusions
     [ch.qos.logback/logback-classic]]]
 


### PR DESCRIPTION
Bump s3-wagon-private version. 

Version 1.3.5 uses a version of: 

- jackson-databind which is not vulnerable to CVE-2020-10650 
- aws-java-sdk-s3 which is vulnerable to CVE-2022-31159