### PR TITLE
Exit with non-zero status when `shadow-cljs.edn` config file not found

### DIFF
--- a/src/main/shadow/cljs/npm/cli.cljs
+++ b/src/main/shadow/cljs/npm/cli.cljs
@@ -850,7 +850,8 @@
           (if-not config-path
             (do (log "Could not find shadow-cljs.edn config file.")
                 (log "To create one run:")
-                (log "  shadow-cljs init"))
+                (log "  shadow-cljs init")
+                (js/process.exit 1))
 
             (let [project-root
                   (path/dirname config-path)


### PR DESCRIPTION
I recently ran `npx shadow-cljs compile app` from the wrong directory and saw the helpful message:

```
Could not find shadow-cljs.edn config file.
To create one run:
  shadow-cljs init
```

But this happened within a script, and I didn't discover the issue until later because shadow-cljs reported a 0 (success) exit status.

I think this case should return non-zero exit status, though you could argue this is a minor edge case and not worth the trouble.


Thanks @thheller for all your open source work and tireless support 😃 