### PR TITLE
Advise users how to get back in

### DIFF
--- a/src/main/shadow/cljs/devtools/server/nrepl_impl.clj
+++ b/src/main/shadow/cljs/devtools/server/nrepl_impl.clj
@@ -213,7 +213,8 @@
       (when (or (= :cljs/quit result)
                 (= :repl/quit result))
         (let [clj-ns (reset-session (:session msg))]
-          (nrepl-out msg {:err "Exited CLJS session. You are now in CLJ again.\n"})
+          (nrepl-out msg {:err "Exited CLJS session. You are now in CLJ again.
+You can use `(shadow.cljs.devtools.api/nrepl-select <build-id>)` to get back in.\n"})
           (nrepl-out msg {:value (str result)
                           :printed-value 1
                           :ns (str clj-ns)})))


### PR DESCRIPTION
CIDER users see this when connecting and then choosing to disconnect from a shadow-cljs repl:

<img width="1011" alt="image" src="https://github.com/thheller/shadow-cljs/assets/1162994/521e3f7b-0cbc-4de8-b1f4-5f20b644a6fd">

It's not necessarily obvious for everyone how to get back in.

Cheers - V