### PR TITLE
Don't export at all without export or export-as meta (Fix Storybook)

### DIFF
--- a/src/main/shadow/build/output.clj
+++ b/src/main/shadow/build/output.clj
@@ -498,8 +498,11 @@
     ;; enumarable only if tagged with :export or :export-as
     (->> (get-in state [:compiler-env ::ana/namespaces ns :defs])
          (vals)
+         (filter (fn [def]
+                   (let [{:keys [export export-as]} (:meta def)]
+                     (or export (string? export-as)))))
          (map (fn [def]
-                (let [{:keys [export export-as] :as def-meta}
+                (let [{:keys [export-as]}
                       (:meta def)
 
                       export-name
@@ -512,9 +515,7 @@
                             (comp/munge def-name))))]
 
                   (str "Object.defineProperty(module.exports, \"" export-name "\", { "
-                       "enumerable: " (or (:export def-meta false)
-                                          (string? export-as))
-                       ", "
+                       "enumerable: true, "
                        "get: function() { return " (comp/munge (:name def)) "; }"
                        " });"))))
          (str/join "\n"))))


### PR DESCRIPTION
Originally changed in https://github.com/thheller/shadow-cljs/commit/ec63c34ae493a7e75e9fe7d5f3ab7cadd1fecfe8 for #710

The latest version of Webpack appears to behave differently than it did at the time the change was made.

> technically still exported to avoid breaking existing builds
but tools like storybook should no longer find them because
of enumerable: false.

Webpack's `require` shim no longer respects `enumerable: false`, which causes [Storybook](https://storybook.js.org/) to see exports it shouldn't.

This change forces properties to not be exported unless they explicitly have `^:export` (or `^{:exportAs ""}`) metadata.

I'm not sure which existing builds mentioned in @thheller's comment might be broken by this change.

If that's a concern, perhaps this change should be behind some sort of flag on the `ns` with the default behavior being the existing "export everything, but use enumerable: false" behavior.

(It's really only necessary for module consumers that expect all exports to mean something specific, like Storybook.)