### PR TITLE
Add :root-source-info to analysis env before calling ClojureScript analyzer

### DIFF
--- a/src/main/shadow/build/compiler.clj
+++ b/src/main/shadow/build/compiler.clj
@@ -241,6 +241,8 @@
            ;; this is anything but empty! requires *cljs-ns*, env/*compiler*
            base-env
            (-> (empty-env state ns)
+               (assoc :root-source-info {:source-type :fragment
+                                         :source-form form})
                (cond->
                  repl-context?
                  (assoc ::repl-context true


### PR DESCRIPTION
This is a small ClojureScript repl compatibility enhancement.
 
ClojureScript repl always adds :root-source-info :source-form to the analysis environment before calling the analyzer (https://github.com/clojure/clojurescript/blob/master/src/main/clojure/cljs/repl.cljc#L509-L510) which allows analysis code down the road to always know what the top level source form is. 

This change also adds it to shadow to make it more compatible.

Why is it needed? 

I'm making tooling that looks at the analysis env and uses this information, it would be great if the tool can work with shadow-cljs also since it is what most people uses. Please let me know if more background is needed. 

Cheers!