### PR TITLE
Fix for repl tagged literals not being pretty-printed

### DIFF
--- a/src/main/shadow/cljs/devtools/server/nrepl_impl.clj
+++ b/src/main/shadow/cljs/devtools/server/nrepl_impl.clj
@@ -187,11 +187,8 @@
                    (nrepl-out msg
                      {:value (edn/read-string
                                {:default
-                                ;; FIXME: piggieback uses own UnknownTaggedLiteral
-                                ;; not sure why? seems like it might as well skip trying to use it
-                                ;; and use the result we had instead.
                                 (fn [sym val]
-                                  (throw (ex-info "unknown edn tags" {:sym sym :val val})))}
+                                  (tagged-literal sym val))}
                                result-as-printed-string)
                       :nrepl.middleware.print/keys #{:value}
                       :ns (str ns)})


### PR DESCRIPTION
This fixes a problem that has been documented here: https://github.com/clojure-emacs/cider/issues/3534

I think it also fixes the original bug that was causing https://github.com/BetterThanTomorrow/calva/issues/1259

I verified it locally and seems to work great!
