### PR TITLE
Add support for the Bun and pnpm package managers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@
 
 ## Requirements
 
-- [node.js](https://nodejs.org) (v6.0.0+, most recent version preferred)
-- [npm](https://www.npmjs.com) (comes bundled with `node.js`) or [yarn](https://www.yarnpkg.com)
+- [Node.js](https://nodejs.org) or [Bun](https://bun.sh)
+- [npm](https://www.npmjs.com) (comes with Node.js), [bun](https://bun.sh) (comes with Bun), [pnpm](https://pnpm.io), or [yarn](https://www.yarnpkg.com)
 - [Java SDK](https://adoptium.net/) (Version 11+, Latest LTS Version recommended)
 
 ## Quick Start
@@ -140,7 +140,7 @@ We also need a simple HTTP server to serve our HTML since modern Browsers all pl
    }}}
 ```
 
-Once the config is saved the server will automatically start and serve the content at http://localhost:8080. There is no need to restart `shadow-cljs`. When opening the above URL the Browser Console should show "Hello World". 
+Once the config is saved the server will automatically start and serve the content at http://localhost:8080. There is no need to restart `shadow-cljs`. When opening the above URL the Browser Console should show "Hello World".
 
 
 To be continued ...
@@ -195,7 +195,7 @@ Please refer to the [User Manual](https://shadow-cljs.github.io/docs/UsersGuide.
 
 ## License
 
-Copyright © 2022 Thomas Heller
+Copyright © 2024 Thomas Heller
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/src/main/shadow/cljs/devtools/server/npm_deps.clj
+++ b/src/main/shadow/cljs/devtools/server/npm_deps.clj
@@ -51,6 +51,12 @@
 (defn guess-node-package-manager [config]
   (or (get-in config [:node-modules :managed-by])
       (get-in config [:npm-deps :managed-by])
+      (let [bun-lock (io/file "bun.lockb")]
+        (when (.exists bun-lock)
+          :bun))
+      (let [pnpm-lock (io/file "pnpm-lock.yaml")]
+        (when (.exists pnpm-lock)
+          :pnpm))
       (let [yarn-lock (io/file "yarn.lock")]
         (when (.exists yarn-lock)
           :yarn))
@@ -87,6 +93,10 @@
         (or (get-in config [:node-modules :install-cmd])
             (get-in config [:npm-deps :install-cmd])
             (case (guess-node-package-manager config)
+              :bun
+              ["bun" "add" "--exact"]
+              :pnpm
+              ["pnpm" "add" "--save-exact"]
               :yarn
               ["yarn" "add" "--exact"]
               :npm

--- a/src/main/shadow/cljs/npm/cli.cljs
+++ b/src/main/shadow/cljs/npm/cli.cljs
@@ -646,6 +646,12 @@
 
 (defn guess-node-package-manager [project-root config]
   (or (get-in config [:node-modules :managed-by])
+      (let [bun-lock (path/resolve project-root "bun.lockb")]
+        (when (fs/existsSync bun-lock)
+          :bun))
+      (let [pnpm-lock (path/resolve project-root "pnpm-lock.yaml")]
+        (when (fs/existsSync pnpm-lock)
+          :pnpm))
       (let [yarn-lock (path/resolve project-root "yarn.lock")]
         (when (fs/existsSync yarn-lock)
           :yarn))
@@ -669,6 +675,10 @@
               false
               (let [[pkg-cmd pkg-args]
                     (case (guess-node-package-manager project-root config)
+                      :bun
+                      ["bun" ["add" "--dev" "shadow-cljs"]]
+                      :pnpm
+                      ["pnpm" ["add" "--save-dev" "shadow-cljs"]]
                       :yarn
                       ["yarn" ["add" "--dev" "shadow-cljs"]]
                       :npm


### PR DESCRIPTION
Closes https://github.com/thheller/shadow-cljs/issues/1196.

This does __not__ add support for running a CLJS REPL on the Bun runtime. Bun users should use an existing REPL like the browser REPL.

References:

* [`bun add` docs](https://bun.sh/docs/cli/add)
* [`pnpm add` docs](https://pnpm.io/cli/add)
