### PR TITLE
Improve the readability for the color of keywords in web console

### DIFF
--- a/src/main/shadow/cljs/devtools/client/console.cljs
+++ b/src/main/shadow/cljs/devtools/client/console.cljs
@@ -89,7 +89,7 @@
           [:td {} (object-ref key)]
           [:td {} (object-ref value)]])])))
 
-(def keyword-style {:color "rgb(136, 19, 145)"})
+(def keyword-style {:color "var(--sys-color-token-keyword, var(--theme-highlight-pink, rgb(136, 19, 145)))"})
 
 (deftype KeywordFormatter []
   Object


### PR DESCRIPTION
Currently the keyword color is hard coded [here](https://github.com/thheller/shadow-cljs/blob/83458310571d0a0f9adae4bc9c55150dbf152705/src/main/shadow/cljs/devtools/client/console.cljs#L92).  The color looks good in light theme, but awful in dark theme. 

Probably it can be changed to `var(--sys-color-token-keyword, var(--theme-highlight-pink, rgb(136, 19, 145)))`

`--sys-color-token-keyword` is available in Chrome based browsers, and `--theme-highlight-pink` is available in Firefox based browsers. 

Some examples:

On Firefox dark mode
![image](https://github.com/user-attachments/assets/f69308af-aab7-497b-bfb9-67468a45dbb9)

On Firefox light mode
![image](https://github.com/user-attachments/assets/e7f6fcab-40b2-4dec-861e-7492f3ae50df)


On Chrome dark mode
![image](https://github.com/user-attachments/assets/479ef4b3-e4f8-459e-b792-3bf1a50fa83d)

On Chrome light mode
![image](https://github.com/user-attachments/assets/ed3e3425-7082-4f61-bb83-8be95593b03b)

