### PR TITLE
Preserve domain of reloaded assets

### DIFF
--- a/src/main/shadow/cljs/devtools/client/browser.cljs
+++ b/src/main/shadow/cljs/devtools/client/browser.cljs
@@ -114,7 +114,9 @@
       (and (or (= (.hasSameDomainAs page-load-uri node-uri))
                (not (.hasDomain node-uri)))
            (= node-abs new)
-           new))))
+           (str (doto node-uri
+                  (.setQuery nil)  ;; remove previous ?r cache bust
+                  (.setPath new)))))))
 
 (defn handle-asset-update [{:keys [updates reload-info] :as msg}]
   (doseq [path updates


### PR DESCRIPTION
This preseves domain of static assets that devtools matches in the case that those assets are served off a different domain from the page.

Thank you @swannodette for guidance!