### PR TITLE
Add docs to `api/get-runtime!` warning about use at the REPL

### DIFF
--- a/src/main/shadow/cljs/devtools/api.clj
+++ b/src/main/shadow/cljs/devtools/api.clj
@@ -99,7 +99,12 @@
       (keys)
       (into #{})))
 
-(defn get-runtime! []
+(defn get-runtime!
+  "NB: The runtime object is too huge to print at the REPL.
+   * (api/get-runtime!) ; => will blow your REPL up
+   * (:config (api/get-runtime!)) ; => works just fine
+   * (:supervisor (api/get-runtime!)) ; => also blows the REPL up"
+  []
   (runtime/get-instance!))
 
 (defn- get-or-start-worker [build-config opts]


### PR DESCRIPTION
I tried `(api/get-runtime!)` at the REPL a few times and wondered why it never returned anything. Then saw a note on some other function about REPL-usage. Then heard the fans on my M4 Mac for the first time ever. 😀

The note I add to the docs here would have helped me avoid trying the bare call at the REPL.