### PR TITLE
Prevent NPE in shadow.test.karma/format-log

### DIFF
--- a/src/main/shadow/test/karma.cljs
+++ b/src/main/shadow/test/karma.cljs
@@ -49,17 +49,22 @@
       (when-not (s/blank? testing-contexts-str)
         (str "\"" testing-contexts-str "\"\n"))
       (cond
-        (and (seq? expected)
-             (seq? actual))
-          (str
-                "expected: " (format-fn indentation expected) "\n"
-                "  actual: " (format-fn indentation (second actual)) "\n"
-                (when-let [diff (format-diff indentation expected (second actual))]
-                  (str "    diff: " diff "\n")))
-        (.hasOwnProperty actual "stack")
-          (str "Exception: " (.-stack actual))                  
+        (nil? actual)
+        (str "expected: " (pr-str expected) "\n"
+             "  actual: nil\n")
+
+        (and (seq? expected) (seq? actual))
+        (str "expected: " (format-fn indentation expected) "\n"
+             "  actual: " (format-fn indentation (second actual)) "\n"
+             (when-let [diff (format-diff indentation expected (second actual))]
+               (str "    diff: " diff "\n")))
+
+        (and (object? actual) (.hasOwnProperty actual "stack"))
+        (str "Exception: " (.-stack actual))
+
         :else
-          (str expected " failed with " actual "\n"))
+        (str "expected: " (pr-str expected) "\n"
+             "  actual: " (pr-str actual) "\n"))
       (when message
         (str " message: " (indent indentation message) "\n")))))
 


### PR DESCRIPTION
If a test assertion fails with an `:actual` value of nil, we get this error:
```
TypeError: Cannot read properties of null (reading 'hasOwnProperty')
    at shadow$test$karma$format_log
```

rather than seeing details about the test failure, this can be quite misleading and a simple nil check will give clearer failure output