### PR TITLE
fix: ensure ESM imports are preserved during build-compile and REPL init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ package-lock.json
 /package.json
 *.log
 src/dev/shadow-css-index.edn
+.clj-kondo/.cache
+.clj-kondo/lock

--- a/packages/shadow-cljs/package-lock.json
+++ b/packages/shadow-cljs/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "shadow-cljs",
-  "version": "3.0.5",
+  "version": "3.3.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "shadow-cljs",
-      "version": "3.0.5",
+      "version": "3.3.4",
       "license": "ISC",
       "dependencies": {
         "buffer": "^6.0.3",

--- a/shadow-cljs.edn
+++ b/shadow-cljs.edn
@@ -255,7 +255,8 @@
    :entries
    [demo.esm.a
     demo.esm.b
-    demo.esm.c]
+    demo.esm.c
+    demo.esm.d]
 
    :js-options
    {:js-package-dirs ["node_modules" "test-env/node_modules"]

--- a/src/dev/demo/esm/d.cljs
+++ b/src/dev/demo/esm/d.cljs
@@ -1,0 +1,8 @@
+(ns demo.esm.d
+  (:require
+   [clojure.string :as cs]))
+
+(def ^:export bar (cs/join [(str :bar "demo.esm.d") "bar"] "/"))
+
+
+

--- a/src/main/shadow/build/output.clj
+++ b/src/main/shadow/build/output.clj
@@ -236,7 +236,12 @@
     (generate-source-map-inline state src output prepend)
     (generate-source-map-regular state src output js-file prepend)))
 
-(defn flush-source [state src-id]
+(defmulti flush-source
+  (fn [state src-id]
+    (get-in state [:shadow.build/config :target])))
+
+(defmethod flush-source :default
+  [state src-id]
   (let [{:keys [resource-name output-name last-modified] :as src}
         (data/get-source-by-id state src-id)
 

--- a/src/main/shadow/build/targets/esm.clj
+++ b/src/main/shadow/build/targets/esm.clj
@@ -252,7 +252,7 @@
           (shared/merge-repl-defines config)
           ))))
 
-(defn flush-source
+(defmethod output/flush-source :esm
   [state src-id]
   (let [{:keys [resource-name output-name last-modified] :as src}
         (data/get-source-by-id state src-id)
@@ -302,7 +302,7 @@
    {:keys [module-id output-name exports prepend append sources depends-on] :as mod}]
 
   (doseq [src-id sources]
-    (async/queue-task state #(flush-source state src-id)))
+    (async/queue-task state #(output/flush-source state src-id)))
 
   (let [module-imports
         (when (seq depends-on)

--- a/src/test/shadow/build/esm_test.clj
+++ b/src/test/shadow/build/esm_test.clj
@@ -1,0 +1,88 @@
+(ns shadow.build.esm-test
+  (:require
+   [clojure.test :refer (deftest is)]
+   [shadow.build :as build]
+   [shadow.build.api :as build-api]
+   [shadow.build.data :as data]
+   [shadow.build.classpath :as cp]
+   [shadow.cljs.util :as util]
+   [shadow.cljs.devtools.server.worker.impl :as worker-impl]
+   [clojure.core.async :as async-chan]
+   [clojure.java.io :as io]
+   [clojure.string :as str])
+  (:import (java.nio.file Files)))
+
+(defn create-temp-dir! [prefix]
+  (.toFile (Files/createTempDirectory prefix (into-array java.nio.file.attribute.FileAttribute []))))
+
+(defn delete-dir! [^java.io.File file]
+  (when (.isDirectory file)
+    (doseq [child (.listFiles file)]
+      (delete-dir! child)))
+  (io/delete-file file))
+
+(deftest test-esm-integrated-compile
+  (let [temp-dir (create-temp-dir! "esm-integrated-")
+        out-dir (-> (io/file temp-dir "out") (.getCanonicalFile))
+        cache-dir (-> (io/file temp-dir "cache") (.getCanonicalFile))]
+    (try
+      (let [cp-service (-> (cp/start cache-dir)
+                           (cp/index-classpath))
+            build-config {:target :esm
+                          :build-id :esm-files
+                          :output-dir (.getAbsolutePath out-dir)
+                          :modules {:main {:entries ['demo.esm.d]}}}
+            
+            initial-state (-> (build-api/init)
+                              (assoc :mode :dev)
+                              (assoc :shadow.cljs.devtools.server.worker.impl/compile-attempt 0)
+                              (build-api/with-logger (util/log-collector))
+                              (build-api/with-classpath cp-service)
+                              (build/configure :dev build-config {}))
+            
+            worker-state {:build-id :esm-files
+                          :build-state initial-state
+                          :channels {:output (async-chan/chan 100)}}]
+        
+        (with-redefs [worker-impl/>!!output (fn [ws msg] ws)
+                      worker-impl/send-to-runtimes (fn [ws msg] ws)
+                      worker-impl/build-find-hooks (fn [bs] bs)]
+          
+          (let [final-worker-state (worker-impl/build-compile worker-state)
+                final-state (:build-state final-worker-state)
+                get-result-by-id (fn [final-state id]
+                                   (let [src (data/get-source-by-id final-state id)
+                                         possible-files [(io/file out-dir (:output-name src))
+                                                         (io/file out-dir "cljs-runtime" (:output-name src))]
+                                         js-file (first (filter #(.exists %) possible-files))]
+                                     js-file))]
+            
+            (is (some? final-state) "Build state should exist after compile")
+            
+            (when final-state
+              (let [d-id (data/get-source-id-by-provide final-state 'demo.esm.d)
+                    cs-id (data/get-source-id-by-provide final-state 'clojure.string)
+                    d-js (and d-id (get-result-by-id final-state d-id))
+                    cs-js (and cs-id (get-result-by-id final-state cs-id))]
+                (is (some? d-id) "demo.esm.d should be found in state")
+                (is (some? cs-id) "clojure.string should be found in state")
+                (is (some? d-js) "Output JS for demo.esm.d should exist")
+                (is (some? cs-js) "Output JS for clojure.string should exist")
+                (when d-js
+                  (let [content (slurp d-js)]
+                    (is (str/includes? content "import \"./cljs_env.js\";") 
+                        "Missing cljs_env import")
+                    (is (str/includes? content "import \"./clojure.string.js\";")
+                        "Missing clojure.string import")
+                    ))
+                (when cs-js
+                  (let [content (slurp cs-js)]
+                    (is (str/includes? content "import \"./cljs_env.js\";")
+                        "Missing cljs_env import")
+                    (is (str/includes? content "import \"./goog.string.string.js\";")
+                        "Missing goog.string.string import")
+                    (is (str/includes? content "import \"./goog.string.stringbuffer.js\";")
+                        "Missing goog.string.stringbuffer import")
+                    )))))))
+      (finally
+        (delete-dir! temp-dir)))))


### PR DESCRIPTION
### The Problem

When building with the `:esm` target and `watch` command, generated JavaScript files containing ESM `import/export` statements were being deleted by `output/flush-source`. This resulted in runtime errors in some special cases (like Cloudflare Worker), as the expected module syntax was destroyed during the build process.

### How to reproduce

Checkout my branch, and then execute the commands:

```bash
git checkout 46f8988ba6a5f1e8f67f9a9ecf1bac5656e0a8ed -- src/main/shadow/build/output.clj src/main/shadow/build/targets/esm.clj
rm -rf .shadow-cljs/builds/esm-files
./build-cli.sh
./packages/shadow-cljs/cli/runner.js watch esm-files
```

Check the top of `out/demo-browser/public/esm-js-auto/cljs-runtime/clojure.string.js`.

The expected contents are like:

```javascript
import "./cljs_env.js";
import "./cljs.core.js";
import "./goog.string.string.js";
import "./goog.string.stringbuffer.js";
goog.provide("clojure.string");
```

The current version result is:

```javascript
goog.provide("clojure.string");
```

### Root Cause

The issue stems from the internal execution sequence during development:

1. the `watch` command called `shadow.cljs.devtools.server.worker.impl/build-compile` at the start
1. then it calls `build/flush` and correctly generates ESM files using target-specific logic
2. then it calls `(ensure-repl-init)` to prepare the REPL.
3. `repl/prepare` triggers a mandatory `(shadow.build.output/flush-sources repl-sources)` to ensure REPL-related files are available on disk.
4. Previously, `shadow.build.output/flush-source` was a static `defn` only aware of standard Google Closure output. When triggered by the REPL, it would blindly overwrite existing files with the wrong format, stripping away ESM-specific features.

### The Fix

Refactored the output flushing logic to be target-aware using Clojure multimethods:

1. Converted `shadow.build.output/flush-source` into a `defmulti` that dispatches based on the build `:target`.
2. Moved the original logic to the `:default` method, maintaining compatibility with other build targets (e.g., `:browser`).
3. Added a specialized `flush-source` for `:esm` in `shadow.build.targets.esm`. This ensures that any flush operation—regardless of whether it's triggered by a build hook or the REPL—always produces the correct ESM format.
