### PR TITLE
Use `string/replace-first` in `exists?` cljs hack

### DIFF
--- a/src/main/shadow/build/cljs_hacks.cljc
+++ b/src/main/shadow/build/cljs_hacks.cljc
@@ -1125,7 +1125,7 @@
     (let [resolved (:name (ana/resolve-var &env x))
           y (cond-> resolved
               (= "js" (namespace resolved)) name)
-          segs (str/split (str (str/replace (str y) "/" ".")) #"\.")
+          segs (str/split (str (str/replace-first (str y) "/" ".")) #"\.")
           n (count segs)
           syms (map
                  #(vary-meta (symbol "js" (str/join "." %))


### PR DESCRIPTION
CLJS has changed the implementation of `exists?` to fix a bug that prevents one to `(defmulti / ,,,)` among other things. You can find more info here: 

https://clojure.atlassian.net/browse/CLJS-3135
https://clojure.atlassian.net/browse/CLJS-3334

Since you have monkey patched `cljs.core/exists?` in cljs hacks and it has the old implementation, `(defmulti / type)` doesn't work in shadow whereas it works in cljs.